### PR TITLE
Detección automática de bloques de código ejecutables

### DIFF
--- a/docs/explanatory_components.yml
+++ b/docs/explanatory_components.yml
@@ -45,30 +45,6 @@ components:
 
       [Ask Rigo how to create a function in Python](https://4geeks.com/ask?query=help-me-understand-how-to-create-a-function-in-python-in-the-simplest-possible-way)
 
-  - name: runnable_code
-    description: >-
-      Code blocks with the runnable metadata that can be executed directly in the application. Users can run the code and see the output, making it interactive for learning programming concepts no matter the programming language. Try to use this component to let the user UNDERSTAND the code and see the output, not just to show the code. If you show code example. Sometimes this component can serve as part of the explanation for a code challenge proposal.
-    goodFor:
-      - code understanding
-      - immediate feedback
-      - understand code
-    avoid:
-      - this is intended only for demonstrative purposes. The student CANNOT edit the code, only run it.
-    example: |
-      ```javascript runnable="true"
-      console.log("Hello, World!");
-      let x = 5;
-      let y = 10;
-      console.log(x + y);
-      ```
-
-      ```python runnable="true"
-      print("Hello, World!")
-      x = 5
-      y = 10
-      print(x + y)
-      ```
-
   - name: image
     intendedUse:
       - educational explanation

--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -35,6 +35,7 @@ import { Icon } from "../../Icon";
 import { generateCodeChallenge } from "../../../utils/creator";
 import { Loader } from "../Loader/Loader";
 import { useCompletionJobStatus } from "../../../hooks/useCompletionJobStatus";
+import { isRunnableCodeBlock } from "../../../utils/runnableDetection";
 
 
 const ClickMeToGetID = ({ id }: { id: string }) => {
@@ -439,6 +440,16 @@ export const Markdowner = ({
               if (metadata) {
                 metadataObject = extractMetadata(metadata);
               }
+              
+              // SIEMPRE usar detección automática, ignorando cualquier atributo runnable explícito
+              const isRunnable = isRunnableCodeBlock(code, lang);
+              if (isRunnable) {
+                metadataObject.runnable = true;
+              } else {
+                // Eliminar runnable si existe pero no es detectado como runnable
+                delete metadataObject.runnable;
+              }
+              
               return {
                 lang,
                 code,

--- a/src/utils/runnableDetection.ts
+++ b/src/utils/runnableDetection.ts
@@ -1,0 +1,258 @@
+/**
+ * Detección automática de bloques de código ejecutables
+ * Similar al patrón usado en EventProxy.ts para detectar inputs
+ */
+
+/**
+ * Detecta si un bloque de código debe ser ejecutable basándose en sus statements de salida
+ * @param code - Contenido del bloque de código
+ * @param language - Lenguaje de programación del bloque
+ * @returns true si el bloque contiene statements de salida que lo hacen ejecutable
+ */
+export const isRunnableCodeBlock = (code: string, language: string): boolean => {
+  // Si el código está vacío o solo espacios, no es runnable
+  const trimmedCode = code.trim();
+  if (!trimmedCode) return false;
+
+  // Detectar según lenguaje (22 lenguajes populares)
+  const normalizedLang = language.toLowerCase();
+  
+  switch (normalizedLang) {
+    case 'javascript':
+    case 'js':
+      return detectJavaScriptRunnable(trimmedCode);
+    case 'typescript':
+    case 'ts':
+      return detectTypeScriptRunnable(trimmedCode);
+    case 'python':
+    case 'py':
+      return detectPythonRunnable(trimmedCode);
+    case 'java':
+      return detectJavaRunnable(trimmedCode);
+    case 'csharp':
+    case 'c#':
+      return detectCSharpRunnable(trimmedCode);
+    case 'cpp':
+    case 'c++':
+      return detectCppRunnable(trimmedCode);
+    case 'c':
+      return detectCRunnable(trimmedCode);
+    case 'php':
+      return detectPHPRunnable(trimmedCode);
+    case 'ruby':
+    case 'rb':
+      return detectRubyRunnable(trimmedCode);
+    case 'go':
+      return detectGoRunnable(trimmedCode);
+    case 'rust':
+    case 'rs':
+      return detectRustRunnable(trimmedCode);
+    case 'swift':
+      return detectSwiftRunnable(trimmedCode);
+    case 'kotlin':
+    case 'kt':
+      return detectKotlinRunnable(trimmedCode);
+    case 'scala':
+      return detectScalaRunnable(trimmedCode);
+    case 'dart':
+      return detectDartRunnable(trimmedCode);
+    case 'r':
+      return detectRRunnable(trimmedCode);
+    case 'bash':
+    case 'shell':
+    case 'sh':
+      return detectBashRunnable(trimmedCode);
+    case 'powershell':
+    case 'ps1':
+      return detectPowerShellRunnable(trimmedCode);
+    case 'lua':
+      return detectLuaRunnable(trimmedCode);
+    case 'julia':
+    case 'jl':
+      return detectJuliaRunnable(trimmedCode);
+    case 'matlab':
+      return detectMATLABRunnable(trimmedCode);
+    case 'perl':
+    case 'pl':
+      return detectPerlRunnable(trimmedCode);
+    default:
+      // Para otros lenguajes, no hacer runnable automáticamente
+      return false;
+  }
+};
+
+// JavaScript: console.log, console.error, console.warn, etc.
+const detectJavaScriptRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const consolePattern = /console\.(log|error|warn|info|debug|trace)\s*\(/;
+  return consolePattern.test(withoutComments);
+};
+
+// TypeScript: igual que JavaScript
+const detectTypeScriptRunnable = detectJavaScriptRunnable;
+
+// Python: print(), sys.stdout.write()
+const detectPythonRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/#.*$/gm, '');
+  const printPattern = /(print\s*\(|sys\.stdout\.write\s*\()/;
+  return printPattern.test(withoutComments);
+};
+
+// Java: System.out.println, System.out.print, System.err.println
+const detectJavaRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const systemOutPattern = /System\.(out|err)\.(println|print)\s*\(/;
+  return systemOutPattern.test(withoutComments);
+};
+
+// C#: Console.WriteLine, Console.Write
+const detectCSharpRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const consolePattern = /Console\.(WriteLine|Write)\s*\(/;
+  return consolePattern.test(withoutComments);
+};
+
+// C++: cout, cerr, printf
+const detectCppRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const outputPattern = /(std::cout|std::cerr|cout|cerr|\bprintf\s*\()/;
+  return outputPattern.test(withoutComments);
+};
+
+// C: printf, fprintf
+const detectCRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const printPattern = /(printf|fprintf)\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// PHP: echo, print, var_dump, print_r
+const detectPHPRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/#.*$/gm, '');
+  const outputPattern = /\b(echo|print|var_dump|print_r)\s*\(/;
+  return outputPattern.test(withoutComments);
+};
+
+// Ruby: puts, print, p
+const detectRubyRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/#.*$/gm, '');
+  const outputPattern = /\b(puts|print|p)\s+/;
+  return outputPattern.test(withoutComments);
+};
+
+// Go: fmt.Println, fmt.Print, fmt.Printf
+const detectGoRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/\/\/.*$/gm, '');
+  const fmtPattern = /fmt\.(Println|Print|Printf)\s*\(/;
+  return fmtPattern.test(withoutComments);
+};
+
+// Rust: println!, print!, eprintln!
+const detectRustRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const macroPattern = /\b(println!|print!|eprintln!|eprint!)\s*\(/;
+  return macroPattern.test(withoutComments);
+};
+
+// Swift: print()
+const detectSwiftRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const printPattern = /print\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// Kotlin: println(), print()
+const detectKotlinRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const printPattern = /(println|print)\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// Scala: println(), print()
+const detectScalaRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const printPattern = /(println|print)\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// Dart: print()
+const detectDartRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const printPattern = /print\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// R: print(), cat()
+const detectRRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/#.*$/gm, '');
+  const outputPattern = /\b(print|cat)\s*\(/;
+  return outputPattern.test(withoutComments);
+};
+
+// Bash/Shell: echo, printf
+const detectBashRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/#.*$/gm, '');
+  const outputPattern = /\b(echo|printf)\s+/;
+  return outputPattern.test(withoutComments);
+};
+
+// PowerShell: Write-Host, Write-Output
+const detectPowerShellRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/#.*$/gm, '');
+  const outputPattern = /\b(Write-Host|Write-Output)\s+/;
+  return outputPattern.test(withoutComments);
+};
+
+// Lua: print()
+const detectLuaRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/--.*$/gm, '');
+  const printPattern = /print\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// Julia: print(), println()
+const detectJuliaRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/#.*$/gm, '');
+  const printPattern = /\b(print|println)\s*\(/;
+  return printPattern.test(withoutComments);
+};
+
+// MATLAB: fprintf(), disp()
+const detectMATLABRunnable = (code: string): boolean => {
+  const withoutComments = code.replace(/%.*$/gm, '');
+  const outputPattern = /\b(fprintf|disp)\s*\(/;
+  return outputPattern.test(withoutComments);
+};
+
+// Perl: print, say
+const detectPerlRunnable = (code: string): boolean => {
+  const withoutComments = code
+    .replace(/#.*$/gm, '')
+    .replace(/=pod[\s\S]*?=cut/g, '');
+  const outputPattern = /\b(print|say)\s+/;
+  return outputPattern.test(withoutComments);
+};
+


### PR DESCRIPTION
### Cambios principales

- **Eliminado** el componente `runnable_code` de `explanatory_components.yml`
- **Implementado** sistema de detección automática basado en statements de salida
- **Soporta** 22 lenguajes de programación populares

### Funcionamiento

Los bloques de código ahora se marcan automáticamente como ejecutables (runnable) cuando contienen statements de salida como:
- JavaScript/TypeScript: `console.log()`, `console.error()`, etc.
- Python: `print()`, `sys.stdout.write()`
- Java: `System.out.println()`
- Y 19 lenguajes más...

La detección ignora cualquier atributo `runnable="true"` explícito en el markdown, siempre usando la detección automática para determinar si un bloque debe ser ejecutable.

### Archivos modificados

- `ide/docs/explanatory_components.yml` - Eliminación del componente
- `ide/src/utils/runnableDetection.ts` - Nuevo módulo de detección
- `ide/src/components/composites/Markdowner/Markdowner.tsx` - Integración de detección automática
