### PR TITLE
Corrige el dropdown vacío del selector de idioma en cursos publicados

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -327,6 +327,16 @@
   align-items: center;
 }
 
+.language-indicator {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--font-size-medium);
+  border: 1px solid transparent;
+  background-color: transparent;
+  cursor: default;
+}
+
 .z-index-2 {
   z-index: 2;
 }


### PR DESCRIPTION
## Descripción

Corrige el problema donde el dropdown de idiomas se mostraba vacío y minúsculo en cursos publicados que solo tienen un idioma disponible.

## Cambios

- **Cuando no hay opciones de cambio disponibles** se muestra un indicador estático del idioma actual.
- Se creó una clase CSS para mantener la consistencia visual (el indicador tiene los mismos estilos que el botón)
- El indicador estático tiene un tooltip que muestra el nombre del idioma actual

## Decisión de diseño

Se optó por usar un `div` estático en lugar de deshabilitar el botón porque:
- Es semánticamente más correcto (no es un elemento interactivo)
- Mejor accesibilidad (los botones deshabilitados pueden ser ignorados por lectores de pantalla)
- Evita confusión al usuario (no sugiere una acción que no puede realizar)
