### PR TITLE
fix(styles): prevent images from expanding beyond original size

### DIFF
--- a/src/components/composites/LessonRenderer/LessonStyles.css
+++ b/src/components/composites/LessonRenderer/LessonStyles.css
@@ -9,6 +9,7 @@
 .lesson-content img {
   margin: 5px auto;
   max-width: 750px;
+  width: auto;
   display: block;
 }
 


### PR DESCRIPTION
Add `width: auto` to `.lesson-content img` to override global `img { width: 100% }` rule.
This ensures images smaller than 750px display at their original size instead of being stretched to 750px width.