### PR TITLE
fix: crear archivo enviando body JSON

### DIFF
--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -272,9 +272,9 @@ export const FetchManager = {
           const url = `${FetchManager.HOST}/exercise/${slug}/file/${filename}`;
           await fetch(url, {
             method: "PUT",
-            body: content,
+            body: JSON.stringify({ content: content ?? "" }),
             headers: {
-              'Content-Type': 'text/plain',
+              "Content-Type": "application/json",
             },
           });
         } catch (e) {
@@ -293,9 +293,9 @@ export const FetchManager = {
         const url = `${FetchManager.HOST}/exercise/${slug}/file/${filename}?slug=${courseSlug}`;
         const res = await fetch(url, {
           method: "PUT",
-          body: content,
+          body: JSON.stringify({ content: content ?? "" }),
           headers: {
-            'Content-Type': 'text/plain',
+            "Content-Type": "application/json",
           },
         });
         if (!res.ok) {

--- a/src/utils/creator.ts
+++ b/src/utils/creator.ts
@@ -334,10 +334,10 @@ export const createFile = async (exerciseSlug: string, filename: string, content
       `${
         DEV_MODE ? "http://localhost:3000" : ""
       }/exercise/${exerciseSlug}/file/${filename}?slug=${courseSlug}`,
-      content,
+      { content: content ?? "" },
       {
         headers: {
-          'Content-Type': 'text/plain',
+          "Content-Type": "application/json",
         },
       }
     );


### PR DESCRIPTION
## Problema
Al crear un archivo nuevo en un code challenge (modo creator / entorno web), el backend devolvía 500: esperaba body JSON y el IDE enviaba texto plano, dejando `body` como `undefined` en el servidor.

## Solución
El IDE envía el contenido en formato JSON `{ "content": "..." }` con `Content-Type: application/json` en `creator.ts` y en `fetchManager.ts` (localhost y creatorWeb), alineado con lo que espera el backend.