### PR TITLE
Añadir debounce en persistencia de cambios a archivos de code challenges

### DIFF
--- a/src/components/composites/Editor/Editor.tsx
+++ b/src/components/composites/Editor/Editor.tsx
@@ -8,7 +8,6 @@ import FeedbackButton from "../../sections/header/FeedbackButton";
 import ResetButton from "../../sections/header/ResetButton";
 
 import { useTranslation } from "react-i18next";
-// import { debounce } from "../../../utils/lib";
 import { Tab } from "../../../types/editor";
 import { CompileOptions } from "../../sections/header/CompileOptions";
 import SimpleButton from "../../mockups/SimpleButton";
@@ -137,7 +136,6 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
       if (mode === "creator") {
         updateFileContent(ex.slug, tab);
       }
-      // debouncedStore();
     }
   };
 

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -178,16 +178,21 @@ export const FetchManager = {
           }
         }
 
-        const exerciseSlug = getSlugFromPath();
-        const url = `${FetchManager.HOST}/courses/${exerciseSlug}/exercises/${slug}/file/${file}`;
-        const response = await fetch(url);
+        try {
+          const exerciseSlug = getSlugFromPath();
+          const url = `${FetchManager.HOST}/courses/${exerciseSlug}/exercises/${slug}/file/${file}`;
+          const response = await fetch(url);
 
-        if (!response.ok) {
+          if (!response.ok) {
+            return { fileContent: "", edited: false, notFound: true };
+          }
+
+          const fileContent = await response.text();
+          return { fileContent, edited: false };
+        } catch (error) {
+          console.error("getFileContent (creatorWeb):", error);
           return { fileContent: "", edited: false, notFound: true };
         }
-
-        const fileContent = await response.text();
-        return { fileContent, edited: false };
       },
     };
 

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -165,7 +165,19 @@ export const FetchManager = {
       },
 
       creatorWeb: async () => {
-        let edited = false;
+        const mode = useStore.getState().mode;
+
+        // In student mode, prefer localStorage when cached so the student doesn't lose progress on reload
+        if (mode !== "creator" && opts.cached) {
+          const cachedEditorTabs = LocalStorage.get(`editorTabs_${slug}`);
+          if (cachedEditorTabs) {
+            const cached = cachedEditorTabs.find((t: any) => t.name === file);
+            if (cached) {
+              return { fileContent: cached.content, edited: true };
+            }
+          }
+        }
+
         const exerciseSlug = getSlugFromPath();
         const url = `${FetchManager.HOST}/courses/${exerciseSlug}/exercises/${slug}/file/${file}`;
         const response = await fetch(url);
@@ -175,19 +187,7 @@ export const FetchManager = {
         }
 
         const fileContent = await response.text();
-
-        if (opts.cached) {
-          const cachedEditorTabs = LocalStorage.get(`editorTabs_${slug}`);
-          if (cachedEditorTabs) {
-            const cached = cachedEditorTabs.find((t: any) => t.name === file);
-            if (cached) {
-              edited = true;
-              return { fileContent: cached.content, edited };
-            }
-          }
-        }
-
-        return { fileContent, edited };
+        return { fileContent, edited: false };
       },
     };
 

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -240,7 +240,10 @@ export const FetchManager = {
           const url = `${FetchManager.HOST}/exercise/${slug}/file/${filename}`;
           await fetch(url, {
             method: "PUT",
-            body: content,
+            body: JSON.stringify({ content: content ?? "" }),
+            headers: {
+              "Content-Type": "application/json",
+            },
           });
         } catch (e) {
           console.log("Error saving file content in CLI");
@@ -258,7 +261,10 @@ export const FetchManager = {
         const url = `${FetchManager.HOST}/exercise/${slug}/file/${filename}?slug=${exerciseSlug}`;
         const res = await fetch(url, {
           method: "PUT",
-          body: content,
+          body: JSON.stringify({ content: content ?? "" }),
+          headers: {
+            "Content-Type": "application/json",
+          },
         });
         if (!res.ok) {
           return false;

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -17,7 +17,7 @@ import { LocalStorage } from "./localStorage";
 import TelemetryManager from "./telemetry";
 import toast from "react-hot-toast";
 import { v4 as uuidv4 } from "uuid";
-import { TSidebar } from "../utils/storeTypes";
+import { TSidebar, TEditorTab } from "../utils/storeTypes";
 import { fixLang } from "../components/sections/header/LanguageButton";
 import useStore from "../utils/store";
 // import axios from "axios";
@@ -146,7 +146,7 @@ export const FetchManager = {
         if (opts.cached) {
           const cachedEditorTabs = LocalStorage.get(`editorTabs_${slug}`);
           if (cachedEditorTabs) {
-            const cached = cachedEditorTabs.find((t: any) => t.name === file);
+            const cached = cachedEditorTabs.find((t: TEditorTab) => t.name === file);
             if (cached) {
               edited = true;
               return { fileContent: cached.content, edited };
@@ -169,12 +169,17 @@ export const FetchManager = {
 
         // In student mode, prefer localStorage when cached so the student doesn't lose progress on reload
         if (mode !== "creator" && opts.cached) {
-          const cachedEditorTabs = LocalStorage.get(`editorTabs_${slug}`);
-          if (cachedEditorTabs) {
-            const cached = cachedEditorTabs.find((t: any) => t.name === file);
-            if (cached) {
-              return { fileContent: cached.content, edited: true };
+          try {
+            const cachedEditorTabs = LocalStorage.get(`editorTabs_${slug}`);
+            if (cachedEditorTabs) {
+              const cached = cachedEditorTabs.find((t: TEditorTab) => t.name === file);
+              if (cached) {
+                return { fileContent: cached.content, edited: true };
+              }
             }
+          } catch (error) {
+            console.error("getFileContent (creatorWeb localStorage):", error);
+            // Fall through to fetch from bucket
           }
         }
 

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -10,7 +10,7 @@ import assessmentComponentsRaw from "../../docs/assessment_components.yml?raw";
 import explanatoryComponentsRaw from "../../docs/explanatory_components.yml?raw";
 // import toast from "react-hot-toast";
 export const DEV_MODE =false;
-export const DEV_URL = "https://1gm40gnb-3000.use2.devtunnels.ms";
+export const DEV_URL = "https://1gm40gnb-3000.use2.devtunnels.ms/";
 
 export const FASTAPI_HOST = "https://ai.4geeks.com";
 // export const FASTAPI_HOST = "http://localhost:8003";
@@ -232,21 +232,38 @@ export const getParamsObject = (): TPossibleParams => {
   return getQueryParams();
 };
 
-export const debounce = (func: (...args: any[]) => void, wait: number) => {
-  let timeout: any;
+export type DebouncedFunction = ((...args: unknown[]) => void) & {
+  cancel: () => void;
+  flush: () => void;
+};
 
-  function debounced(this: any, ...args: any[]) {
+export const debounce = (func: (...args: unknown[]) => void, wait: number): DebouncedFunction => {
+  let timeout: ReturnType<typeof setTimeout>;
+  let lastArgs: unknown[] | null = null;
+
+  const debounced = (...args: unknown[]) => {
+    lastArgs = args;
     clearTimeout(timeout);
     timeout = setTimeout(() => {
-      func.apply(this, args);
+      lastArgs = null;
+      func(...args);
     }, wait);
-  }
+  };
 
   debounced.cancel = () => {
     clearTimeout(timeout);
+    lastArgs = null;
   };
 
-  return debounced;
+  debounced.flush = () => {
+    if (lastArgs !== null) {
+      clearTimeout(timeout);
+      func(...lastArgs);
+      lastArgs = null;
+    }
+  };
+
+  return debounced as DebouncedFunction;
 };
 
 

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -12,6 +12,7 @@ import {
   getParamsObject,
   replaceSlot,
   debounce,
+  type DebouncedFunction,
   removeSpecialCharacters,
   ENVIRONMENT,
   getEnvironment,
@@ -74,6 +75,39 @@ type TFile = {
 };
 
 const HOST = getHost();
+
+/** Debounce delay (ms) for persisting file content to bucket in creator mode. */
+const BUCKET_SAVE_DEBOUNCE_MS = 1500;
+
+/** Per-file debounced savers: key = `${slug}:${filename}`. Used only in creator mode. */
+const debouncedBucketSavers = new Map<string, DebouncedFunction>();
+
+function debouncedSaveFileContent(
+  slug: string,
+  filename: string,
+  content: string,
+  waitMs = BUCKET_SAVE_DEBOUNCE_MS
+) {
+  const key = `${slug}:${filename}`;
+  if (!debouncedBucketSavers.has(key)) {
+    debouncedBucketSavers.set(
+      key,
+      debounce(
+        (s: string, fn: string, c: string) => {
+          FetchManager.saveFileContent(s, fn, c);
+        },
+        waitMs
+      )
+    );
+  }
+  debouncedBucketSavers.get(key)!(slug, filename, content);
+}
+
+export function flushPendingBucketSaves() {
+  for (const saver of debouncedBucketSavers.values()) {
+    saver.flush();
+  }
+}
 
 // const chatSocket = io(`${FASTAPI_HOST}`);
 
@@ -968,6 +1002,9 @@ The user's set up the application in "${language}" language, give your feedback 
   },
 
   setPosition: async (newPosition) => {
+    // Flush any pending debounced bucket saves before switching exercise.
+    flushPendingBucketSaves();
+
     const {
       startConversation,
       fetchReadme,
@@ -2012,7 +2049,7 @@ The user's set up the application in "${language}" language, give your feedback 
   updateFileContent: async (exerciseSlug, tab, updateTabs = false) => {
     const { exercises, updateEditorTabs, setShouldBeTested } = get();
 
-    let newExercises = exercises.map((e) => {
+    const newExercises = exercises.map((e) => {
       if (e.slug === exerciseSlug) {
         return {
           ...e,
@@ -2031,12 +2068,15 @@ The user's set up the application in "${language}" language, give your feedback 
       }
     });
 
-    await FetchManager.saveFileContent(exerciseSlug, tab.name, tab.content);
+    // State updates: immediate (UI stays responsive).
     set({ exercises: newExercises });
     setShouldBeTested(true);
     if (updateTabs) {
       updateEditorTabs();
     }
+
+    // Network PUT: debounced so we avoid 429; last content wins.
+    debouncedSaveFileContent(exerciseSlug, tab.name, tab.content);
   },
   createNewFile: async (filename: string, content: string = "") => {
     const { getCurrentExercise, editorTabs, setEditorTabs, fetchExercises, mode } = get();

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -1196,7 +1196,7 @@ The user's set up the application in "${language}" language, give your feedback 
     compilerSocket.openWindow(data);
   },
   updateEditorTabs: (newTab = null) => {
-    const { getCurrentExercise, editorTabs, environment, setFileLoadNotFound } =
+    const { getCurrentExercise, editorTabs, environment, setFileLoadNotFound, mode } =
       get();
 
     const exercise = getCurrentExercise();
@@ -1260,7 +1260,8 @@ The user's set up the application in "${language}" language, give your feedback 
         }
         content = notFound ? "" : fileContent;
 
-        if (!notFound && "content" in element && element.content !== content) {
+        // Only persist to bucket in creator mode; avoid writing in student mode.
+        if (mode === "creator" && !notFound && "content" in element && element.content !== content) {
           await FetchManager.saveFileContent(
             exercise.slug,
             element.name,


### PR DESCRIPTION
## Problema
**Ámbito**:
Archivos vinculados a code challenges.

**Descripción**:
La persistencia en GCS de las modificaciones de los archivos no tiene debounce, por lo que produce error 429 si se escribe rápido varios caracteres.

## Solución
- Implementar debounce en el llamado a la función que persiste los cambios en el bucket

**Nota**:
- A la persistencia en el localstorage y el estado global NO se le aplica debounce