### PR TITLE
Eliminar la detección de li.task-list-item de LessonInspector

### DIFF
--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -109,9 +109,8 @@ const LessonInspector = () => {
     intervalRef.current = setTimeout(async () => {
       const katexErrors = document.querySelectorAll("span.katex-error");
       const errorTexts = document.querySelectorAll("text.error-text");
-      const taskListItems = document.querySelectorAll("li.task-list-item");
 
-      if (katexErrors.length > 0 || errorTexts.length > 0 || taskListItems.length > 0) {
+      if (katexErrors.length > 0 || errorTexts.length > 0) {
         let foundErrors = "There are\n";
         
         if (katexErrors.length > 0) {
@@ -129,15 +128,6 @@ const LessonInspector = () => {
           });
           foundErrors += `</MERMAID_ERRORS>\n`;
         }
-        
-        if (taskListItems.length > 0) {
-          foundErrors += `<TASK_LIST_ITEMS> ${taskListItems.length} task list items that are not properly formatted as quizzes:\n`;
-          taskListItems.forEach((item) => {
-            foundErrors += `  - ${item.textContent || ""}\n`;
-          });
-          foundErrors += `</TASK_LIST_ITEMS>\n`;
-        }
-
 
         if (environment !== "creatorWeb") {
           console.log("not creator web, skipping fix lesson");


### PR DESCRIPTION
## Problema

[LessonInspector puede eliminar el contenido de una lección](https://github.com/learnpack/learnpack/issues/1979)

## Solución

- Eliminar la detección de li.task-list-item de LessonInspector para evitar la potencial pérdida de contenido y UX confusa.
- La detección de errores KaTeX y Mermaid permanecen sin cambios.

## Consecuencias
- Los errores de formato de las quizzes ya no se intentan arreglar automáticamente y sin control ni entendimiento del usuario.
- Tener en cuenta que la implementación anterior no solo era riesgosa (posible pérdida de contenido) y con una UX confusa (sucedían cambios que el usuario no podía explicar ni controlar), sino que además, no siempre era efectiva (a veces el error de formato persistía de todas formas).