### PR TITLE
Fixed ul creator wrapper spacing

### DIFF
--- a/src/components/composites/LessonRenderer/LessonStyles.css
+++ b/src/components/composites/LessonRenderer/LessonStyles.css
@@ -43,6 +43,19 @@
   }
 }
 
+.lesson-content ul:not(:first-child),
+.lesson-content ol:not(:first-child) {
+  margin-block: 15px;
+}
+
+.lesson-content .creator-wrapper.ul {
+  margin-block: 15px;
+}
+
+.lesson-content .creator-wrapper.ul > .text-in-editor > ul {
+  margin-block: 0;
+}
+
 .creator-wrapper {
   position: relative;
 


### PR DESCRIPTION
This PR fixes the inconsistent spacing for ul/ol blocks wrapped by CreatorWrapper in the lesson editor. It adds explicit vertical margins for lists inside .lesson-content and normalizes spacing for .creator-wrapper.ul so list blocks align visually with surrounding paragraphs/headings and the hover/drag highlight matches the visible content.

<img width="1355" height="271" alt="image" src="https://github.com/user-attachments/assets/c752290f-5e9b-402a-ba44-3f7e4b8f510a" />

<img width="1273" height="261" alt="image" src="https://github.com/user-attachments/assets/1be8a805-b2e0-4144-8292-85128e523975" />
