### PR TITLE
fix: improve code editor tab bar drag and text wrapping

### DIFF
--- a/src/components/composites/Editor/Editor.css
+++ b/src/components/composites/Editor/Editor.css
@@ -1,7 +1,47 @@
+.tabs-scroll-container {
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+  flex: 1;
+}
+
 .tabs {
   display: flex;
   align-items: center;
   gap: 2px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  cursor: grab;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tabs.dragging {
+  cursor: grabbing;
+  user-select: none;
+}
+
+.tabs-fade-left,
+.tabs-fade-right {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 128px;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.tabs-fade-left {
+  left: 0;
+  background: linear-gradient(to right, var(--bg-color, #fff), transparent);
+}
+
+.tabs-fade-right {
+  right: 0;
+  background: linear-gradient(to left, var(--bg-color, #fff), transparent);
 }
 .tab {
   display: flex;

--- a/src/components/composites/Editor/Editor.tsx
+++ b/src/components/composites/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState} from "react";
+import React, { useCallback, useEffect, useRef, useState} from "react";
 import MonacoEditor from "@monaco-editor/react";
 import useStore from "../../../utils/store";
 import { LocalStorage } from "../../../managers/localStorage";
@@ -116,6 +116,14 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
   const [isRenaming, setIsRenaming] = useState<boolean>(false);
   const isBuildable = useStore((s) => s.isBuildable);
   const isTesteable = useStore((s) => s.isTesteable);
+
+  const tabsRef = useRef<HTMLDivElement | null>(null);
+  const [showFadeLeft, setShowFadeLeft] = useState(false);
+  const [showFadeRight, setShowFadeRight] = useState(false);
+  const isDraggingTabsRef = useRef(false);
+  const dragPointerIdRef = useRef<number | null>(null);
+  const dragStartXRef = useRef(0);
+  const dragScrollLeftRef = useRef(0);
 
   const updateContent = (id: number, content: string) => {
     const newTabs = tabs.map((tab) =>
@@ -443,6 +451,102 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
     }
   }, [tabs]);
 
+  useEffect(() => {
+    const el = tabsRef.current;
+    if (!el) return;
+
+    const updateFades = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      setShowFadeLeft(scrollLeft > 0);
+      setShowFadeRight(scrollLeft + clientWidth < scrollWidth - 1);
+    };
+
+    updateFades();
+    el.addEventListener("scroll", updateFades);
+    window.addEventListener("resize", updateFades);
+
+    return () => {
+      el.removeEventListener("scroll", updateFades);
+      window.removeEventListener("resize", updateFades);
+    };
+  }, [tabs.length]);
+
+  const handleTabsWheel: React.WheelEventHandler<HTMLDivElement> = (e) => {
+    const el = tabsRef.current;
+    if (!el) return;
+    if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+      e.preventDefault();
+      el.scrollLeft += e.deltaY;
+    }
+  };
+
+  const DRAG_THRESHOLD_PX = 8;
+  const hasPointerDownRef = useRef(false);
+
+  const endTabsDrag = useCallback((pointerId: number) => {
+    const el = tabsRef.current;
+    if (!el) return;
+    if (dragPointerIdRef.current !== null) {
+      try {
+        el.releasePointerCapture(pointerId);
+      } catch {
+        // ignore
+      }
+      dragPointerIdRef.current = null;
+    }
+    isDraggingTabsRef.current = false;
+    hasPointerDownRef.current = false;
+    el.classList.remove("dragging");
+  }, []);
+
+  const handleDragStart: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    const el = tabsRef.current;
+    if (!el) return;
+    hasPointerDownRef.current = true;
+    isDraggingTabsRef.current = false;
+    dragPointerIdRef.current = null;
+    dragStartXRef.current = e.clientX;
+    dragScrollLeftRef.current = el.scrollLeft;
+    const pointerId = e.pointerId;
+    const onPointerUpGlobal = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      hasPointerDownRef.current = false;
+      if (dragPointerIdRef.current !== null) {
+        endTabsDrag(ev.pointerId);
+      }
+      window.removeEventListener("pointerup", onPointerUpGlobal);
+      window.removeEventListener("pointercancel", onPointerUpGlobal);
+    };
+    window.addEventListener("pointerup", onPointerUpGlobal);
+    window.addEventListener("pointercancel", onPointerUpGlobal);
+  };
+
+  const handleDragMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    const el = tabsRef.current;
+    if (!el) return;
+    if (!hasPointerDownRef.current) return;
+    if (!isDraggingTabsRef.current) {
+      if (Math.abs(e.clientX - dragStartXRef.current) < DRAG_THRESHOLD_PX) return;
+      isDraggingTabsRef.current = true;
+      dragPointerIdRef.current = e.pointerId;
+      el.classList.add("dragging");
+      dragStartXRef.current = e.clientX;
+      dragScrollLeftRef.current = el.scrollLeft;
+      try {
+        el.setPointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+    }
+    const dx = e.clientX - dragStartXRef.current;
+    el.scrollLeft = dragScrollLeftRef.current - dx;
+  };
+
+  const handleDragEnd: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (e.pointerId !== dragPointerIdRef.current) return;
+    endTabsDrag(e.pointerId);
+  };
+
   const onReset = () => {
     setOpenedModals({ reset: true });
   };
@@ -470,14 +574,23 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
       style={{ display: `${tabs.length === 0 ? "none" : "block"}` }}
     >
       <div
-        className="tabs"
+        className="tabs-scroll-container"
         style={{ display: terminal === "only" ? "none" : "flex" }}
       >
-        {filteredTabs.map((tab) => (
-          <div
-            key={tab.id + tab.name}
-            className={`tab ${tab.isActive ? "active" : ""}`}
-          >
+        <div
+          className="tabs"
+          ref={tabsRef}
+          onWheel={handleTabsWheel}
+          onPointerDown={handleDragStart}
+          onPointerMove={handleDragMove}
+          onPointerUp={handleDragEnd}
+          onPointerLeave={handleDragEnd}
+        >
+          {filteredTabs.map((tab) => (
+            <div
+              key={tab.id + tab.name}
+              className={`tab ${tab.isActive ? "active" : ""}`}
+            >
             {editingTabId === tab.id ? (
               <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
                 <input
@@ -524,6 +637,7 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
+                    className="whitespace-nowrap"
                     onClick={() => handleTabClick(tab.id)}
                     onDoubleClick={() => handleDoubleClick(tab)}
                   >
@@ -627,6 +741,9 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
             </Tooltip>
           </div>
         )}
+        </div>
+        {showFadeLeft && <div className="tabs-fade-left" />}
+        {showFadeRight && <div className="tabs-fade-right" />}
       </div>
 
       {!(terminal === "only") && (


### PR DESCRIPTION
# Changes
- Updated the Code Editor tab bar to support horizontal scrolling for long file names without breaking layout.
- Added scrolling to the tab bar using mouse wheel or click-and-drag.
- Added gradient indicators to show the user that tab is scrollable.
- Removed text wrapping from tabs to maintain clean UI.

![brave_RvVEi9B151](https://github.com/user-attachments/assets/5019cfb8-7666-49cb-8397-eda464b6cd2e)
