### PR TITLE
fix: fetch sidebar.json from /.learn/ in published courses

### DIFF
--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -610,7 +610,7 @@ export const FetchManager = {
       },
       localStorage: async () => {
         try {
-          const sidebar = await fetch(`/sidebar.json`);
+          const sidebar = await fetch(`/.learn/sidebar.json`);
           const json = await sidebar.json();
           return json;
         } catch (e) {


### PR DESCRIPTION
Published courses serve sidebar from .learn/sidebar.json, but the IDE was requesting /sidebar.json in localStorage mode, causing 403 errors and preventing translated sidebar content from loading.

Related issue: https://github.com/learnpack/learnpack/issues/1991