### PR TITLE
Corrección en la telemetría de quizzes (MCQ) y fill-in-the-blank

### DIFF
--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -1251,7 +1251,7 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
     TelemetryManager.registerTesteableElement(Number(currentExercisePosition), {
       type: "quiz",
       hash: hashRef.current,
-      is_completed: true,
+      is_completed: submission.status === "SUCCESS",
       searchString: code.slice(0, 200) || "",
     });
 

--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -11,6 +11,7 @@ import { atomDark as prismStyle } from "react-syntax-highlighter/dist/esm/styles
 import { QuizRenderer } from "../QuizRenderer/QuizRenderer";
 import {
   buildFillInTheBlankIdentityString,
+  getLatestQuizSubmission,
   makeFillInTheBlankSubmission,
 } from "../QuizRenderer/quizSubmissionUtils";
 import { RigoQuestion } from "../RigoQuestion/RigoQuestion";
@@ -1109,11 +1110,11 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
         );
         if (submissions.length === 0) return;
 
-        const lastSubmission = submissions[submissions.length - 1];
-        if (!lastSubmission?.selections?.length) return;
+        const latestSubmission = getLatestQuizSubmission(submissions);
+        if (!latestSubmission?.selections?.length) return;
 
         const restored: Record<string, string> = {};
-        lastSubmission.selections.forEach((sel) => {
+        latestSubmission.selections.forEach((sel) => {
           const m = /^blank_(\d+)$/.exec(sel.question);
           if (m) restored[m[1]] = sel.answer;
         });

--- a/src/components/composites/QuizRenderer/QuizRenderer.tsx
+++ b/src/components/composites/QuizRenderer/QuizRenderer.tsx
@@ -9,7 +9,11 @@ import { Notifier } from "../../../managers/Notifier";
 import { svgs } from "../../../assets/svgs";
 import TelemetryManager, { TQuizSubmission } from "../../../managers/telemetry";
 import { eventBus } from "@/managers/eventBus";
-import { makeQuizSubmission, type TQuizGroup } from "./quizSubmissionUtils";
+import {
+  getLatestQuizSubmission,
+  makeQuizSubmission,
+  type TQuizGroup,
+} from "./quizSubmissionUtils";
 
 type TQuiz = {
   hash: string;
@@ -107,19 +111,18 @@ export const QuizRenderer = ({ children }: { children: any }) => {
 
         if (submissions.length === 0) return;
 
-        // Get the last submission (successful or failed)
-        const lastSubmission = submissions[submissions.length - 1];
+        const latestSubmission = getLatestQuizSubmission(submissions);
 
-        if (!lastSubmission) return;
-       
+        if (!latestSubmission) return;
+
         // Restore attempts history
         quiz.current.attempts = submissions;
 
         // Create an object with restored selections for React state
         const restored: Record<string, string> = {};
         
-        // Restore selections from telemetry
-        lastSubmission.selections?.forEach((selection) => {
+        // Restore selections from telemetry (latest attempt by timestamp)
+        latestSubmission.selections?.forEach((selection) => {
           // Store directly in state for React to render
           restored[selection.question] = selection.answer;
           
@@ -173,8 +176,10 @@ export const QuizRenderer = ({ children }: { children: any }) => {
   };
 
   const onGroupRendered = async (title: string) => {
-    quiz.current.renderedGroups.push(title);
-    
+    if (!quiz.current.renderedGroups.includes(title)) {
+      quiz.current.renderedGroups.push(title);
+    }
+
     if (quiz.current.renderedGroups.length === liChildren.length) {
       quiz.current.hash = await asyncHashText(
         quiz.current.renderedGroups.join(" ")
@@ -190,13 +195,6 @@ export const QuizRenderer = ({ children }: { children: any }) => {
       return;
     }
     if (Object.keys(quiz.current.groups).length === liChildren.length) {
-      const hash = await asyncHashText(
-        Object.values(quiz.current.groups)
-          .map((group) => group.title)
-          .join(" ")
-      );
-      quiz.current.hash = hash;
-
       const currentStep = await getTelemetryStep(
         Number(currentExercisePosition)
       );

--- a/src/components/composites/QuizRenderer/QuizRenderer.tsx
+++ b/src/components/composites/QuizRenderer/QuizRenderer.tsx
@@ -250,7 +250,7 @@ export const QuizRenderer = ({ children }: { children: any }) => {
         {
           type: "quiz",
           hash: quiz.current.hash,
-          is_completed: true,
+          is_completed: submission.status === "SUCCESS",
           searchString: quiz.current.renderedGroups[0] || "",
         }
       );

--- a/src/components/composites/QuizRenderer/quizSubmissionUtils.ts
+++ b/src/components/composites/QuizRenderer/quizSubmissionUtils.ts
@@ -45,6 +45,39 @@ export const makeQuizSubmission = (
   };
 };
 
+/**
+ * Returns a comparable timestamp for ordering submissions (newest wins).
+ * Prefer ended_at; fall back to started_at; unknown values become 0.
+ */
+export const getQuizSubmissionTimestampMs = (s: TQuizSubmission): number => {
+  const ended =
+    typeof s.ended_at === "number" && !Number.isNaN(s.ended_at)
+      ? s.ended_at
+      : 0;
+  const started =
+    typeof s.started_at === "number" && !Number.isNaN(s.started_at)
+      ? s.started_at
+      : 0;
+  return Math.max(ended, started);
+};
+
+/**
+ * Picks the most recent submission by timestamp. Does not assume array order
+ * (server/reconciliation may return submissions in any order).
+ */
+export const getLatestQuizSubmission = (
+  submissions: TQuizSubmission[]
+): TQuizSubmission | null => {
+  if (!submissions.length) {
+    return null;
+  }
+  return submissions.reduce((latest, current) =>
+    getQuizSubmissionTimestampMs(current) > getQuizSubmissionTimestampMs(latest)
+      ? current
+      : latest
+  );
+};
+
 /** Stable identity string for fill-in-the-blank blocks (code + ordered numeric metadata). */
 export const buildFillInTheBlankIdentityString = (
   code: string,

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1180,7 +1180,12 @@ const TelemetryManager: ITelemetryManager = {
 
         const now = Date.now();
         const hasPendingTasks = this.hasPendingTasks(stepPosition);
-        if (!hasPendingTasks && !step.completed_at) {
+        const isSuccessfulSubmission = data?.status === "SUCCESS";
+        if (
+          isSuccessfulSubmission &&
+          !hasPendingTasks &&
+          !step.completed_at
+        ) {
           step.completed_at = now;
           step.is_completed = true;
         } else {


### PR DESCRIPTION
Antes, al responder un MCQ o fill-in-the-blank, el ejercicio se marcaba como `is_completed: true` aunque las respuestas fueran incorrectas.

### Cambios incluidos
- `is_completed` ahora depende del resultado real del submission (`SUCCESS`/`ERROR`).
- El step de telemetría solo se completa si la submission fue exitosa.
- El `quiz_hash` se calcula una única vez (al renderizar), evitando que
  distintos intentos del mismo quiz queden bajo hashes distintos.
- Se restaura siempre el último intento por timestamp al volver a la lección.