### PR TITLE
fix: show translation sync/retry for incomplete languages

### DIFF
--- a/src/components/sections/header/LanguageButton.tsx
+++ b/src/components/sections/header/LanguageButton.tsx
@@ -354,7 +354,10 @@ const LanguageDropdown = ({ toggleDrop }: ILanguageDropdown) => {
         const displayStatus = resolveTranslationStatus(syllabus, exercises || [], l, pendingEntry);
         const missingCount = getMissingSlugsForLang(exercises || [], l).length;
         const isDisabled = missingCount > 0;
-        const showRetry = mode === "creator" && displayStatus === "error" && missingCount > 0;
+        const isTranslating = displayStatus === "pending" || displayStatus === "translating";
+        // Show sync button whenever the language is incomplete and not actively translating.
+        // This covers both explicit error cases and "incomplete with no tracked pending state".
+        const showRetry = mode === "creator" && missingCount > 0 && !isTranslating;
         const showErrorIcon = mode === "creator" && displayStatus === "error" && missingCount === 0;
 
         return (


### PR DESCRIPTION
Display the retry control whenever READMEs are missing for a language and it is not pending/translating, not only when status is error.