### PR TITLE
Telemetría: Corregir bugs relacionados a la gestión de testeable_elements

### DIFF
--- a/.agents/skills/telemetry/SKILL.md
+++ b/.agents/skills/telemetry/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: telemetry-ide
+description: >
+  Complete knowledge of the telemetry system in the LearnPack IDE (ide/).
+  Use this skill whenever working on any telemetry-related task in this repo:
+  new tracking features, event bug fixes, changes to local/server reconciliation,
+  data schema modifications, Rigobot integration, engagement/frustration metrics,
+  or any question about how telemetry data flows. Also applies for onboarding
+  new developers to this module. Always use this skill when the user touches
+  TelemetryManager, registerTelemetryEvent, registerTesteableElement,
+  hasPendingTasks, is_completed, testeable_elements, quiz_submission, open_step,
+  reconcileTelemetry, normalizeTelemetrySchema, workout_session, lesson_rendered,
+  completeStepIfReadOnly, onLessonRendered, activeHashes, or anything related to
+  completion_rate, step tracking, or telemetry submission/persistence.
+---
+
+# Telemetry in the LearnPack IDE
+
+## General architecture
+
+The IDE is the **central telemetry agent**: it accumulates all events, stores them
+locally in `localStorage`, and syncs them with Rigobot. The CLI acts as a local
+storage bridge for `os`/`vscode` agents.
+
+```
+User (action)
+    │
+    ▼
+store.tsx / components
+    │  register events via registerTelemetryEvent()
+    ▼
+TelemetryManager (singleton)       ← src/managers/telemetry.ts
+    │  accumulates in .current (in memory)
+    ├─ save() → localStorage["TELEMETRY"]   (cloud agent)
+    ├─ save() → POST /telemetry             (os/vscode agents)
+    └─ submit() → POST Rigobot + Breathecode
+```
+
+### The IDE as source of truth for step structure (cloud)
+
+In the cloud environment, the IDE is the **only actor that knows**:
+- Which exercises currently exist in the tutorial (from `configObject.exercises`)
+- Their current slugs and correct order
+- Which steps are testeable
+
+The server stores telemetry blobs but has no knowledge of the tutorial structure.
+This means **server data can arrive with steps in a different order or with stale
+slugs** if the tutorial was updated between sessions. The IDE must always enforce
+the current exercise structure when reconciling.
+
+### Step indexing contract
+
+`current.steps` is a flat array built from `configObject.exercises.map(...)`.
+The **array index** is the canonical identifier — `current.steps[N]` always
+corresponds to `exercises[N]`.
+
+**All code that accesses `current.steps` must use the array index**, not
+`exercise.position`. The two values can diverge if:
+- Exercises come from the server with non-sequential position values
+- The tutorial was updated and exercises were reordered between sessions
+
+Concretely:
+- `registerTelemetryEvent()` → uses `currentExercisePosition` (array index) ✓
+- `registerTesteableElement()` → **must use `currentExercisePosition`** (array index), not `exercise.position`. Using `.position` causes testeable elements to land in a different step slot, breaking `hasPendingTasks` checks.
+
+## Main file
+
+**`src/managers/telemetry.ts`** — contains almost all the logic:
+- `TelemetryManager` singleton: `start()`, `save()`, `submit()`, `registerStepEvent()`, `reconcileTelemetry()`
+- TypeScript types: `ITelemetryJSONSchema`, `TStep`, `TCompilationAttempt`, etc.
+- Bootstrap functions, server fetch, base64 encoding
+
+## Event types
+
+| Event | Registered in | Trigger |
+|-------|--------------|---------|
+| `compile` | `store.tsx` | Compilation result via socket |
+| `test` | `store.tsx` | Test result via socket |
+| `ai_interaction` | `Rigobot/Agent.tsx`, `Rigobot/NewAgent.tsx` | AI completes response |
+| `open_step` | `store.tsx` (guarded by `telemetryReady`) | User navigates to a step |
+| `quiz_submission` | `QuizRenderer.tsx`, `Markdowner.tsx`, `OpenQuestion.tsx` | User submits quiz |
+
+Additionally, `LessonRenderer.tsx` emits the `lesson_rendered` eventBus event whenever
+`currentContent` changes. This is not a `registerStepEvent` call — it's an internal
+signal used by `onLessonRendered` to detect read-only steps (see below).
+
+## How to register a new event
+
+1. Call `TelemetryManager.registerStepEvent(eventType, data)` from the component/store
+2. The event is appended to the corresponding array in `TelemetryManager.current.steps[n]`
+3. `save()` is called automatically after each registration
+4. Add the new type to `TStep` (see `references/schema.md`)
+
+For compilation/test events, data must be base64-encoded:
+```typescript
+// telemetry.ts:386-391
+const encode = (s: string) => btoa(encodeURIComponent(s))
+```
+
+## Lifecycle and submission triggers
+
+**Bootstrap** (on IDE startup):
+1. Resolve `package_id` from slug — 5s timeout
+2. `GET ${RIGOBOT_HOST}/v1/learnpack/telemetry?include_buffer=true` — 5s timeout
+3. Load from `localStorage`
+4. Reconcile (see Reconciliation section)
+5. If source is `"local"`, submit immediately
+
+**Automatic submissions** (`submit()` → Rigobot + Breathecode):
+- Test completes with `exit_code === 0`
+- Quiz submitted
+- Step opened
+- Tab hidden
+- Page closed — beacon with `keepalive: true`
+
+**Server refresh:**
+- On tab focus if idle > 5 minutes (`TELEMETRY_VISIBILITY_REFRESH_IDLE_MS`)
+
+## Local ↔ server reconciliation
+
+Function: `reconcileTelemetry()` — `telemetry.ts:214-314`
+
+Strategy: **"most recent `last_interaction_at` wins"**
+
+| Scenario | Result |
+|----------|--------|
+| Server only | Use server data |
+| Local only | Use local + auto-submit to server |
+| Both have data | Most recent wins; tie → server |
+| Neither | Create new blob with UUID |
+
+### Step merge on reconciliation (`normalizeTelemetrySchema`)
+
+After choosing a winner blob, steps are **not** used as-is. They are merged into
+`freshSteps` (the current exercise list) by `slug`:
+
+- **Structural fields** (`slug`, `position`, `files`, `is_testeable`) always come
+  from `freshSteps` — this enforces correct array ordering.
+- **Activity fields** (`compilations`, `tests`, `ai_interactions`, `quiz_submissions`,
+  `testeable_elements`, `is_completed`, `completed_at`, `opened_at`, `sessions`)
+  are preserved from the stored blob when present.
+- Steps in the stored blob that have no matching slug in `freshSteps` are discarded.
+- Steps in `freshSteps` with no match in the stored blob get blank defaults.
+
+## Local storage
+
+- **Cloud**: `localStorage["TELEMETRY"]` — PII sanitized (FERPA): `fullname → "[REDACTED]"`, email removed
+- **OS/VSCode**: `POST http://localhost:PORT/telemetry` → saved to `${configPath}/telemetry.json` in the CLI
+
+## External APIs
+
+See `references/apis.md` for full endpoints, headers, and payloads.
+
+## Data schema
+
+See `references/schema.md` for the complete TypeScript types with all fields.
+
+## Key files
+
+See `references/key-files.md` for the full file map with relevant line numbers.
+
+## Privacy
+
+- `fullname` → `"[REDACTED]"` in localStorage (`src/utils/piiSanitizer.ts:85-88`)
+- Email is **never** sent in telemetry
+- `user.email`, `user.first_name`, `user.last_name`, `user.github` removed from localStorage
+- No explicit opt-out mechanism; without a Rigobot token, no data is sent to the server
+
+## How `is_completed` gets set (state machine)
+
+`step.is_completed` and `step.completed_at` are always set together. There are five paths:
+
+| Path | Mechanism | Key conditions |
+|------|-----------|----------------|
+| Test passes | `case "test"` | `exit_code === 0` AND `!hasPendingTasks(pos)` AND `!step.completed_at` |
+| Quiz succeeds | `case "quiz_submission"` | `status === "SUCCESS"` AND no other active pending elements AND `!step.completed_at` |
+| Navigate away from step | `case "open_step"` — auto-completes **previous** step | `prev.testeable_elements?.length > 0` AND `!hasPendingTasks(prevStep)` AND `!prev.completed_at` |
+| Read-only step (any step) | `onLessonRendered` → `completeStepIfReadOnly` — 7s debounce after `lesson_rendered` | `!step.testeable_elements?.length` AND `!step.is_testeable` AND `!step.completed_at` |
+| Last step — user clicks Finish | `completeStepIfReadOnly` via `last_lesson_finished` in eventListener | Same as above — safety net if 7s debounce hasn't fired yet |
+
+**Critical:** `open_step` only auto-completes the previous step if `testeable_elements`
+is **non-empty**. Steps with empty `testeable_elements` are never completed by departure
+— they rely exclusively on `onLessonRendered` (7s debounce) to decide if they're
+read-only. This prevents a race condition where a quiz step whose components haven't
+mounted yet looks indistinguishable from a read-only step.
+
+### `completeStepIfReadOnly`
+
+Called from `onLessonRendered` (for all steps) and from the `last_lesson_finished`
+handler (safety net for the last step). It is a no-op if:
+- `step.completed_at` already set (already completed via quiz/test)
+- `step.testeable_elements?.length > 0` (has registered quiz/test elements — not read-only)
+- `step.is_testeable === true` (code-test step whose element may not have registered yet)
+
+### `onLessonRendered`
+
+Listens to the `lesson_rendered` eventBus event. On each emission:
+1. Cancels any pending debounce (prevents stale completions from previous step)
+2. Schedules `completeStepIfReadOnly(stepPosition)` with a **7-second debounce**
+
+The 7s window gives quiz/FITB/OQ components time to mount, compute their hashes,
+and call `registerTesteableElement`. If no elements are registered after 7s, the
+step is genuinely read-only and gets marked complete.
+
+**Diagnosing `is_completed` bugs:**
+- Stays `false` unexpectedly → check `hasPendingTasks`: any stale/orphaned element?
+  Is `testeable_elements` in the correct step slot (array index)? Did `registerTesteableElement`
+  run before or after `registerStepEvent`?
+- Set `true` unexpectedly → was `open_step` fired before `testeable_elements` was
+  populated (race condition)? Check `telemetryReady` guard. Did `onLessonRendered`
+  fire 7s after a step that had slow quiz registration?
+
+## `testeable_elements` and `hasPendingTasks`
+
+`testeable_elements` is a per-step array of trackable sub-tasks (quiz questions,
+code tests). The step is only complete when all active items are done.
+
+### `hasPendingTasks(stepPosition)` — logic
+
+```
+1. If testeable_elements is empty → return false (no tasks, nothing pending)
+2. If any element with type === "test" is incomplete → return true
+3. Filter quiz elements. If none → return false
+4. For each language in activeHashes:
+     collect the hashes of this step that appear in that language's set
+     if all of them are is_completed === true → return false  (OR logic: one complete language = done)
+5. return true  (no language found where all active quizzes are done)
+```
+
+**Key behavior:** `hasPendingTasks` uses **OR logic across languages** — the step is
+considered done if ALL active quiz hashes of **at least one language** are completed.
+Orphaned hashes (not in `activeHashes`) are completely ignored.
+
+### `hasPendingTasksInAnyLesson()` — logic
+
+Does **not** delegate to `hasPendingTasks`. Uses `is_completed` directly:
+
+```typescript
+return steps.some(step =>
+  (step.is_testeable || step.testeable_elements?.length) && !step.is_completed
+)
+```
+
+This avoids any dependency on `activeHashes` (in-memory, session-only) and works
+correctly for all steps, including those not visited in the current session.
+
+**The sidebar** (`ExercisesList.tsx`) uses `TelemetryManager.isStepCompleted(position)`
+(reads `step.is_completed` from persisted data) instead of `hasPendingTasks`, which
+requires in-memory session state only available for the currently rendered step.
+
+### The double-call pattern
+
+For quizzes and tests, a single "user completed X" maps to two calls:
+
+```
+registerTelemetryEvent(event, data)      → records attempt, checks hasPendingTasks,
+                                           may set is_completed, calls submit()
+
+registerTesteableElement(index, element) → updates testeable_elements cache,
+                                           calls save() only (NOT submit())
+```
+
+`registerStepEvent` runs synchronously and reads `testeable_elements` **before**
+`registerTesteableElement` updates it. When diagnosing completion bugs, always
+check the call order in the triggering code.
+
+**The fix for quiz completion** (`case "quiz_submission"`): instead of `hasPendingTasks()`
+(which would include the current quiz's stale element), check only OTHER active elements:
+`step.testeable_elements?.some(e => e.hash !== data.quiz_hash && !e.is_completed)`.
+
+## Course completion architecture
+
+### Layer 1 — `step.completed_at` (metrics source of truth)
+
+`metrics.ts` derives step status from `step.completed_at`, **not** `step.is_completed`:
+
+```typescript
+let status = step.completed_at ? "completed" : step.opened_at ? "attempted" : "unread";
+```
+
+If `completed_at` is missing, the step is never counted in `completion_rate`.
+
+### Layer 2 — `hasPendingTasks` / `hasPendingTasksInAnyLesson` (real-time gate)
+
+- `hasPendingTasks(stepPosition)` — language-aware, `activeHashes`-filtered check for the **current rendered step**
+- `hasPendingTasksInAnyLesson()` — reads `is_completed` directly; works for all steps including unvisited ones
+
+### Layer 3 — "Finish" button and last_lesson_finished modal
+
+```
+isFinishDisabled = isLastExercise && (hasPendingTasks || hasPendingTasksInAnyLesson)
+```
+
+When the student clicks Finish: `eventBus.emit("last_lesson_finished")` →
+`EventListener` re-checks `hasPendingTasksInAnyLesson()` → confetti + modal.
+
+### Layer 4 — `completion_rate` in the telemetry payload
+
+```typescript
+completion_rate = (steps_with_completed_at / total_steps) * 100
+```
+
+## Hash generation per testeable element type
+
+Each testeable element is identified by a SHA-256 hash (`asyncHashText`, `lib.tsx:361`):
+
+| Type | Input to `asyncHashText` |
+|------|--------------------------|
+| **Quiz (MCQ)** | `renderedGroups.join(" ")` — rendered group titles (`QuizRenderer.tsx`) |
+| **Open question** | `metadata.eval` — the `eval` attribute string (`Markdowner.tsx`) |
+| **Fill-in-the-blank** | `buildFillInTheBlankIdentityString(code, metadata)` — format: `fitb:<code>:<idx>=<answer>\|...` |
+
+All three types are **language-sensitive**: hash inputs come from README content,
+which is fetched per locale. The same element in a different language produces a
+different hash.
+
+### Known limitation: content edits orphan progress
+
+Any text change to quiz content produces a new hash. The old element stays in
+`testeable_elements` with its previous `is_completed` state. The student loses
+visible progress on that question. Orphaned elements are ignored by `hasPendingTasks`
+(via `activeHashes` filter) so they don't block completion, but they accumulate over
+time.
+
+### `activeHashes` — in-memory orphan filter
+
+`TelemetryManager.activeHashes: Map<language, Set<hash>>` — **not persisted**,
+rebuilt each session as quiz components mount.
+
+**How it works:**
+- `registerTesteableElement` adds the hash to `activeHashes[language]` when
+  `type === "quiz"` and a language is provided.
+- `hasPendingTasks` iterates `activeHashes` entries and applies OR logic across
+  languages (see above). Hashes not in any language's set are ignored.
+- Code tests (`type: "test"`) are never orphaned — they are always evaluated
+  regardless of `activeHashes`.
+
+`activeHashes` is reset to an empty `Map` at the start of each `TelemetryManager.start()`
+call, preventing hash leakage when switching courses in the same tab.
+
+## Multi-language progress in `testeable_elements`
+
+Quiz elements (MCQ, open question, FITB) produce different hashes per language.
+Progress per language is tracked independently via `TTesteableElement.language`.
+
+- `language` is set on registration for `type === "quiz"` elements by `QuizRenderer.tsx`,
+  `Markdowner.tsx` (FITB), and `OpenQuestion.tsx`. Omitted for `type: "test"`.
+- `hasPendingTasks` uses OR logic: if ALL active hashes of **at least one language**
+  are completed, the step is done. This means completing a course in Spanish does not
+  require having also completed quizzes in English.
+- `hasPendingTasksInAnyLesson()` reads `step.is_completed` directly and is not
+  affected by language at all.
+- Legacy stored elements without `language` (from before multi-language support) are
+  treated as matching every language check — they will block completion in any locale
+  until re-answered.
+
+**If completion looks wrong in a multi-language course:**
+1. Inspect `step.testeable_elements` — confirm quiz rows include `language`.
+2. Check that `registerTesteableElement` is being called with the `language` argument
+   in `QuizRenderer.tsx`, `Markdowner.tsx`, `OpenQuestion.tsx`.
+3. Legacy rows without `language` can block completion across locales.
+
+## workout_session mechanics
+
+`workout_session` is an array of `{ started_at, ended_at? }` objects tracking study periods.
+Each `TelemetryManager.start()` call closes the previous session (sets `ended_at =
+last_interaction_at` if no `ended_at`) and opens a new one. Handled by
+`normalizeWorkoutSession()` inside `normalizeTelemetrySchema`.
+
+## Important gotchas
+
+- **`open_step` is guarded by `telemetryReady`** — `setPosition` only fires
+  `open_step` when `telemetryReady === true`. This prevents a 2s retry from being
+  enqueued before `TelemetryManager.start()` completes, which could trigger completion
+  logic with stale state. `startTelemetry()` registers the initial `open_step` itself.
+
+- **Race condition: `startTelemetry` + `getOrCreateActiveSession`** — both are called
+  concurrently on startup. If `getOrCreateActiveSession` resolves after telemetry is
+  ready and calls `setPosition(N)` for the same step that's already open, `open_step(N)`
+  fires with `prevStep === N === stepPosition`. The guard `this.prevStep !== stepPosition`
+  prevents this from triggering auto-completion.
+
+- **`open_step` never completes steps with empty `testeable_elements`** — read-only step
+  completion relies on `onLessonRendered` (7s debounce). Never add completion logic to
+  `open_step` for steps with `testeable_elements.length === 0` — it cannot distinguish
+  a read-only step from a quiz step whose components haven't mounted yet.
+
+- **`TelemetryManager` may not be initialized when the first event fires** → retry loop
+  of 3 attempts with 2s delay. Note: `open_step` is excluded from this retry mechanism
+  via the `telemetryReady` guard in `setPosition`.
+
+- **Keys persisted in localStorage have a strict whitelist** (`telemetry.ts:539-555`) —
+  fields outside the whitelist are discarded during normalization.
+
+- **No HTTP retry**: if a POST fails, it is logged and discarded.
+
+- **Source code, stdout, and stderr are always base64-encoded.**
+
+- **Never use `exercise.position` to index `current.steps`** — always use the array
+  index. `exercise.position` can differ from the array index if the tutorial was
+  reordered or the server returned steps out of order.
+
+- **`step.completed_at` is the real source of truth** for metrics — `metrics.ts` only
+  reads `completed_at`. If debugging why a step doesn't count in `completion_rate`,
+  check `completed_at`, not `is_completed`.
+
+- **`hasPendingTasksInAnyLesson()` blocks the entire course** — a single step with
+  `is_completed: false` and `is_testeable || testeable_elements.length` will prevent
+  the Finish button and completion modal, even for unvisited steps.
+
+- **`console.log` objects in browser devtools show live references** — expanding an
+  object in the console shows its *current* state, not the state at log time. When
+  debugging `is_completed` mutations, always log the primitive value separately
+  (`console.log(step.is_completed)`) alongside the object to get an accurate snapshot.

--- a/.agents/skills/telemetry/references/apis.md
+++ b/.agents/skills/telemetry/references/apis.md
@@ -1,0 +1,132 @@
+# Telemetry APIs — IDE
+
+## Environment variables
+
+```
+VITE_RIGOBOT_HOST     → https://rigobot.herokuapp.com  (default)
+VITE_BREATHECODE_HOST → https://breathecode.herokuapp.com  (default)
+```
+
+The auth token comes from the user's session (Rigobot token).
+
+---
+
+## Rigobot — Primary endpoint
+
+### GET /v1/learnpack/telemetry
+**Purpose:** Fetch telemetry from the server on startup or refresh.
+**File:** `telemetry.ts:154`
+
+```
+GET ${RIGOBOT_HOST}/v1/learnpack/telemetry
+  ?user_ids=<user_id>
+  &package_slug=<slug>
+  &package_ids=<package_id>
+  &include_buffer=true
+  &include_steps=true
+
+Headers:
+  Authorization: Token <rigobot_token>
+```
+
+Timeout: `FETCH_TELEMETRY_TIMEOUT_MS = 5000ms`
+Response: `ITelemetryJSONSchema | null`
+
+---
+
+### POST /v1/learnpack/telemetry
+**Purpose:** Batch submission of the full blob.
+**File:** `telemetry.ts:59`
+
+```
+POST ${RIGOBOT_HOST}/v1/learnpack/telemetry
+
+Headers:
+  Authorization: Token <rigobot_token>
+  Content-Type: application/json
+
+Body: ITelemetryJSONSchema (full blob with computed metrics)
+```
+
+Also called with `keepalive: true` on `pagehide`/`beforeunload` (beacon).
+
+---
+
+### GET /v1/learnpack/package/${slug}/
+**Purpose:** Resolve `package_id` from the package slug.
+**File:** `telemetry.ts:89`
+
+```
+GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
+
+Headers:
+  Authorization: Token <rigobot_token>
+```
+
+Timeout: `RESOLVE_PACKAGE_ID_TIMEOUT_MS = 5000ms`
+Response: `{ id: number, ... }`
+
+---
+
+## Breathecode — Secondary endpoint
+
+### POST (URL configured in the package)
+**Purpose:** Alternate batch submission, complementary to Rigobot.
+**File:** `telemetry.ts:23-56`
+
+```
+POST <config.batch_url>
+
+Headers:
+  Authorization: Token <breathecode_token>
+  Content-Type: application/json
+
+Body: ITelemetryJSONSchema (same payload as Rigobot)
+```
+
+The URL comes from `config.telemetry.batch` in the LearnPack package config.
+
+---
+
+## Streaming — Individual real-time events
+
+**Purpose:** Send individual events during the session (not batch).
+**File:** `telemetry.ts:1342-1362`
+
+```
+POST <config.telemetry.streaming>
+
+Body: {
+  slug: string
+  telemetry_id: string
+  user_id: string
+  step_position: number
+  event: string
+  data: any
+}
+```
+
+---
+
+## CLI — Local bridge (os/vscode agents)
+
+**File:** `telemetry.ts:361-384`
+
+```
+GET http://localhost:<PORT>/telemetry
+→ Retrieve telemetry saved in the CLI
+
+POST http://localhost:<PORT>/telemetry
+  Content-Type: application/json
+  Body: ITelemetryJSONSchema
+→ Save telemetry to the CLI (local file)
+```
+
+---
+
+## Error behavior
+
+- **Timeout** (package resolve or fetch): returns `null`, continues with local data
+- **4xx/5xx HTTP**: error is logged, Promise is rejected, **no retry**
+- **Tab closed**: beacon with `keepalive: true` — one-way, no delivery confirmation
+- **TelemetryManager not initialized**: retry loop of 3 attempts with 2s delay

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -1,0 +1,106 @@
+# Key Files Map — IDE Telemetry
+
+## Core file
+
+### `src/managers/telemetry.ts`
+The heart of all telemetry logic in the IDE.
+
+| Lines | Contents |
+|-------|----------|
+| 1-50 | Timeout constants, imports, auxiliary types |
+| 23-56 | `sendBatchTelemetryBreathecode()` |
+| 58-75 | `sendBatchTelemetryRigobot()` |
+| 82-107 | `getRigobotPackageIdBySlug()` |
+| 129-193 | `fetchTelemetryFromServer()` |
+| 214-314 | `reconcileTelemetry()` — local/server reconciliation logic |
+| 386-391 | `encode()` / `decode()` — base64 for source code |
+| 539-555 | localStorage key whitelist |
+| 587-640 | `normalize()` — normalizes blob before saving |
+| 649 | Metrics and indicators computation in `submit()` |
+| 759-870 | `TelemetryManager.start()` — full bootstrap |
+| 859 | Auto-submit when source is "local" |
+| 964-1007 | `refreshFromServerIfStale()` |
+| 1061 | `open_step` registration in store |
+| 1114-1124 | Event registration retry loop (3 attempts, 2s) |
+| 1164 | Submit on test complete with exit_code === 0 |
+| 1197 | Submit on quiz submitted |
+| 1212 | Session duration registration |
+| 1234 | Complete last step of the course |
+| 1240 | Submit on step opened |
+| 1250 | `save()` after each event |
+| 1296-1324 | `submit()` — batch send to Rigobot + Breathecode |
+| 1332 | Sync to CLI when agent is os/vscode |
+| 1342-1362 | `streamEvent()` — individual streaming |
+
+---
+
+## Store (state logic)
+
+### `src/store.tsx`
+
+| Lines | Contents |
+|-------|----------|
+| 424, 480 | Test success/failure handlers → `test` event registration |
+| 520, 538 | Compilation success/failure handlers → `compile` event registration |
+| 547 | Compilation event start |
+| 1061 | `registerTelemetryEvent("open_step", ...)` |
+| 2611 | Submit on tab hidden (`visibilitychange`) |
+| 2621 | Beacon on page close (`pagehide`/`beforeunload`) |
+| 2624 | `visibilitychange` listener |
+| 2625-2626 | `beforeunload` / `pagehide` listeners |
+| 2647 | Alternative `open_step` registration |
+
+---
+
+## Components that register events
+
+### `src/components/composites/Agent.tsx`
+- Line **618**: Registers `ai_interaction` when AI response completes
+
+### `src/components/composites/NewAgent.tsx`
+- Line **544**: Registers `ai_interaction` (new agent variant)
+
+### `src/components/composites/QuizRenderer.tsx`
+- Line **76-84**: `registerTesteableElement` on mount (debounced 2s), passes `language`
+- Line **249-258**: `registerTesteableElement` on quiz submission, passes `language`
+- Line **228**: Registers `quiz_submission`
+
+### `src/components/composites/Markdowner.tsx` (`FillInTheBlankRenderer`)
+- Line **1082-1088**: `registerTesteableElement` on mount (debounced 2s), passes `language`
+- Line **1239**: Registers `quiz_submission` (inline quizzes in markdown)
+
+### `src/components/composites/OpenQuestion.tsx`
+- Line **101-103**: `registerTesteableElement` on mount (debounced 2s), passes `language`
+- Line **237-246**: `registerTesteableElement` on successful evaluation, passes `language`
+- Line **250**: Registers `quiz_submission` (open-ended questions)
+
+### `src/components/composites/LessonRenderer/LessonRenderer.tsx`
+- Emits `lesson_rendered` eventBus event in a `useEffect` whenever `currentContent` or
+  `currentExercisePosition` changes. This signals `TelemetryManager.onLessonRendered`
+  to start the 7s debounce for read-only step detection.
+
+### `src/managers/eventBus.ts`
+- Typed event bus (mitt). Relevant telemetry events:
+  - `lesson_rendered: { stepPosition: number }` — emitted by LessonRenderer, consumed by `onLessonRendered`
+  - `last_lesson_finished: {}` — triggers `completeStepIfReadOnly(lastPos)` in eventListener
+  - `position_changed: {}` — step navigation confirmed
+
+---
+
+## Privacy and sanitization
+
+### `src/utils/piiSanitizer.ts`
+- Lines **78-91**: Masks `fullname → "[REDACTED]"` in telemetry
+- Lines **101-120**: Hook on `LocalStorage.set()`
+- Removes: `email`, `user.email`, `user.first_name`, `user.last_name`, `user.github`
+
+### `src/managers/localStorage.ts`
+- Lines **16-23**: `LocalStorage.set()` — sanitizer interception point
+- Telemetry key: `"TELEMETRY"`
+
+---
+
+## Models / shared types
+
+### `src/models/`
+Telemetry types live primarily in `src/managers/telemetry.ts`, not in separate model files.

--- a/.agents/skills/telemetry/references/schema.md
+++ b/.agents/skills/telemetry/references/schema.md
@@ -1,0 +1,162 @@
+# Telemetry Schema — IDE
+
+## Main types (src/managers/telemetry.ts)
+
+### ITelemetryJSONSchema (root blob)
+
+```typescript
+interface ITelemetryJSONSchema {
+  telemetry_id?: string          // blob UUID
+  user_id: string
+  fullname: string               // "[REDACTED]" in localStorage
+  slug: string                   // package/course slug
+  package_id?: number | string   // Rigobot ID
+  version: string                // e.g. "CLOUD:0.46.0"
+  cohort_id: string | null
+  academy_id: string | null
+  agent: "cloud" | "os" | "vscode"
+  tutorial_started_at: number    // timestamp ms
+  last_interaction_at: number    // timestamp ms — used for reconciliation
+  steps: TStep[]
+  workout_session: TWorkoutSession[]
+  global_metrics?: GlobalMetrics
+  global_indicators?: TIndicators
+}
+```
+
+### TStep
+
+```typescript
+interface TStep {
+  slug: string
+  position: number
+  files: IFile[]
+  is_testeable: boolean
+  opened_at?: number             // timestamp ms
+  completed_at?: number          // timestamp ms
+  sessions?: number[]            // session durations in ms
+  compilations: TCompilationAttempt[]
+  tests: TTestAttempt[]
+  ai_interactions: TAIInteraction[]
+  quiz_submissions: TQuizSubmission[]
+  testeable_elements?: TTesteableElement[]
+  metrics?: StepMetrics          // computed in submit()
+  indicators?: TIndicators       // computed in submit()
+}
+```
+
+### TCompilationAttempt / TTestAttempt
+
+```typescript
+interface TCompilationAttempt {
+  source_code: string   // base64(encodeURIComponent(code))
+  stdout: string        // base64
+  stderr?: string       // base64, only present on error
+  exit_code: number     // 0 = success
+  started_at: number    // timestamp ms
+  ended_at: number      // timestamp ms
+}
+// TTestAttempt has the same structure
+```
+
+### TAIInteraction
+
+```typescript
+interface TAIInteraction {
+  student_message: string
+  source_code: string   // base64
+  ai_response: string
+  started_at: number
+  ended_at: number
+}
+```
+
+### TQuizSubmission
+
+```typescript
+interface TQuizSubmission {
+  quiz_hash: string
+  selections: Array<{
+    question: string
+    answer: string
+    isCorrect: boolean
+    feedback?: string
+  }>
+  status: "SUCCESS" | "ERROR"
+  percentage: number
+  started_at: number
+  ended_at: number
+}
+```
+
+### TTesteableElement
+
+```typescript
+interface TTesteableElement {
+  hash: string
+  type: "quiz" | "test"
+  is_completed?: boolean
+  language?: string              // locale code ("en", "es", …); set for type === "quiz", omitted for "test"
+  searchString?: string          // first 200 chars of content, for debugging/display
+  metrics?: TTesteableElementMetrics
+}
+```
+
+`language` is the key that enables multi-language progress tracking. It is set by
+`QuizRenderer.tsx`, `Markdowner.tsx` (FITB), and `OpenQuestion.tsx` when calling
+`registerTesteableElement`. Elements without `language` (legacy data) are treated
+as matching every locale check in `hasPendingTasks`.
+
+### TWorkoutSession
+
+```typescript
+interface TWorkoutSession {
+  started_at: number
+  ended_at?: number
+}
+```
+
+### TIndicators
+
+```typescript
+interface TIndicators {
+  engagement_indicator: number   // 0-100
+  frustration_indicator: number  // 0-100
+}
+```
+
+## Per-step computed metrics (StepMetrics)
+
+Computed automatically on every `submit()`:
+
+- `time_spent` — total time on the step (ms)
+- `comp_struggles` — failed compilations
+- `comp_success` — successful compilations
+- `test_struggles` — failed tests
+- `test_success` — passed tests
+- `quiz_struggles` / `quiz_success`
+- `streak_*` — consecutive streaks
+- `ai_used` — boolean, whether Rigobot was used
+- `is_abandoned` — has failures but no successes
+
+## localStorage persistence whitelist
+
+Only these top-level keys are saved (telemetry.ts:539-555):
+
+```
+telemetry_id, user_id, fullname, slug, package_id, version,
+cohort_id, academy_id, agent, tutorial_started_at, last_interaction_at,
+steps, workout_session, global_metrics, global_indicators
+```
+
+Any key outside this list is discarded by `normalize()`.
+
+## Binary data encoding
+
+```typescript
+// telemetry.ts:386-391
+const encode = (s: string) => btoa(encodeURIComponent(s))
+const decode = (s: string) => decodeURIComponent(atob(s))
+```
+
+Applies to: `source_code`, `stdout`, `stderr` in compilations and tests.

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 .env
 
 example
+
+.claude/
+.cursor/
+.codex/

--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -140,7 +140,6 @@ const LessonInspector = () => {
 
 
         if (environment !== "creatorWeb") {
-          console.log("not creator web, skipping fix lesson");
           return;
         }
 
@@ -192,14 +191,17 @@ export const LessonRenderer = memo(() => {
   const isTesteable = useStore((s) => s.isTesteable);
   const lastTestResult = useStore((s) => s.lastTestResult);
   const isBuildable = useStore((s) => s.isBuildable);
+  const currentExercisePosition = useStore((s) => s.currentExercisePosition);
 
-  console.log("Rendering LessonRenderer", {
-    currentContent,
-    editingContent,
-    agent,
-    environment,
-    lastState,
-  });
+  // Notify telemetry that the lesson content has rendered, so it can
+  // determine (after a debounce window) whether the step is read-only.
+  useEffect(() => {
+    if (currentContent && currentExercisePosition != null) {
+      eventBus.emit("lesson_rendered", {
+        stepPosition: Number(currentExercisePosition),
+      });
+    }
+  }, [currentContent, currentExercisePosition]);
 
   const onReset = () => {
     setOpenedModals({ reset: true });

--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -1045,6 +1045,7 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
     recordConsumable,
     toastFromStatus,
     reportEnrichDataLayer,
+    language,
   } = useStore((state) => ({
     token: state.token,
     setOpenedModals: state.setOpenedModals,
@@ -1056,6 +1057,7 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
     recordConsumable: state.useConsumable,
     toastFromStatus: state.toastFromStatus,
     reportEnrichDataLayer: state.reportEnrichDataLayer,
+    language: state.language,
   }));
 
   // Extract correct answers from metadata
@@ -1083,7 +1085,7 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
       type: "quiz",
       hash: hashRef.current,
       searchString: code.slice(0, 200) || "",
-    });
+    }, language);
   };
 
   const debouncedRegisterFitb = debounce(registerFitb, 2000);
@@ -1254,7 +1256,7 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
       hash: hashRef.current,
       is_completed: submission.status === "SUCCESS",
       searchString: code.slice(0, 200) || "",
-    });
+    }, language);
 
     if (submission.status === "SUCCESS") {
       toastFromStatus("quiz-success");

--- a/src/components/composites/OpenQuestion/OpenQuestion.tsx
+++ b/src/components/composites/OpenQuestion/OpenQuestion.tsx
@@ -55,6 +55,7 @@ export const Question = ({
     token,
     setOpenedModals,
     telemetryReady,
+    language,
   } = useStore((state) => ({
     replaceInReadme: state.replaceInReadme,
     mode: state.mode,
@@ -66,6 +67,7 @@ export const Question = ({
     getTelemetryStep: state.getTelemetryStep,
     setOpenedModals: state.setOpenedModals,
     telemetryReady: state.telemetryReady,
+    language: state.language,
   }));
 
   const [feedback, setFeedback] = useState<TFeedback | null>(null);
@@ -98,7 +100,7 @@ export const Question = ({
       hash: questionHash,
       searchString: metadata.eval as string,
     }
-    TelemetryManager.registerTesteableElement(Number(currentExercisePosition), elem);
+    TelemetryManager.registerTesteableElement(Number(currentExercisePosition), elem, language);
   };
 
   const debouncedRegister = debounce(register, 2000);
@@ -239,7 +241,8 @@ export const Question = ({
                 hash: hashRef.current,
                 is_completed: true,
                 searchString: metadata.eval as string,
-              }
+              },
+              language
             );
             playEffect("success");
           } else {

--- a/src/components/composites/QuizRenderer/QuizRenderer.tsx
+++ b/src/components/composites/QuizRenderer/QuizRenderer.tsx
@@ -43,6 +43,7 @@ export const QuizRenderer = ({ children }: { children: any }) => {
     token,
     setOpenedModals,
     telemetryReady,
+    language,
   } = useStore((state) => ({
     registerTelemetryEvent: state.registerTelemetryEvent,
     maxQuizRetries: state.maxQuizRetries,
@@ -54,6 +55,7 @@ export const QuizRenderer = ({ children }: { children: any }) => {
     token: state.token,
     setOpenedModals: state.setOpenedModals,
     telemetryReady: state.telemetryReady,
+    language: state.language,
   }));
 
 
@@ -77,7 +79,8 @@ export const QuizRenderer = ({ children }: { children: any }) => {
         type: "quiz",
         hash: quiz.current.hash,
         searchString: quiz.current.renderedGroups[0] || "",
-      }
+      },
+      language
     );
   };
 
@@ -250,7 +253,8 @@ export const QuizRenderer = ({ children }: { children: any }) => {
           hash: quiz.current.hash,
           is_completed: submission.status === "SUCCESS",
           searchString: quiz.current.renderedGroups[0] || "",
-        }
+        },
+        language
       );
       useConsumable("ai-compilation");
       quiz.current.started_at = 0;

--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -7,7 +7,6 @@ import toast from "react-hot-toast";
 import {
   createStep,
   deleteExercise,
-  markLessonAsDone,
   renameExercise,
   synchronizeSyllabus,
 } from "../../../utils/creator";
@@ -113,7 +112,6 @@ const AddExerciseButton = ({
     }
     catch (error) {
       toast.error(t("errorGeneratingExercise"), { id: toastId });
-      console.log(error);
     }
   };
 
@@ -235,7 +233,6 @@ export default function ExercisesList({ closeSidebar, mode }: IExerciseList) {
       setSelectedExercises([]);
     } catch (error) {
       toast.error(t("errorTranslatingExercises"), { id: toastId });
-      console.log(error, "Error");
     }
   };
 
@@ -270,11 +267,9 @@ export default function ExercisesList({ closeSidebar, mode }: IExerciseList) {
       
       // Refresh sidebar
       await getSidebar();
-      
-      console.log("Sync result:", result);
+    
     } catch (error) {
       toast.error("Error synchronizing syllabus", { id: toastId });
-      console.error(error);
     }
   };
 
@@ -415,7 +410,6 @@ function ExerciseCard({
         await fetchExercises();
       } catch (e) {
         toast.error(t("errorRenamingExercise"), { id: toastId });
-        console.log(e);
       }
     } else {
       setIsEditing(true);
@@ -436,7 +430,6 @@ function ExerciseCard({
 
   const isDone = TelemetryManager.isTesteable(position) && TelemetryManager.isStepCompleted(position);
   const isTesteable = TelemetryManager.isTesteable(position);
-  console.table({ graded, done, isDone, isTesteable });
 
 
   return (
@@ -507,37 +500,8 @@ function ExerciseCard({
           foundInSyllabus.status === "GENERATING" && (
             <>
               <Loader color="gray" extraClass="svg-blue" />
-              {DEV_MODE && (
-                <button
-                  onClick={() => {
-                    toast.success("Marking as done...");
-                    markLessonAsDone(
-                      config.config.slug,
-                      slug,
-                      token
-                    );
-                  }}
-                >
-                  IS DONE
-                </button>
-              )}
             </>
           )}
-        {foundInSyllabus && DEV_MODE && (
-          <button
-            onClick={() => {
-              toast.success("Marking as done...");
-              markLessonAsDone(
-                config.config.slug,
-                slug,
-                token
-              );
-            }}
-          >
-
-            {foundInSyllabus.status}
-          </button>
-        )}
         {foundInSyllabus &&
           !foundInSyllabus.generated &&
           foundInSyllabus.status === "PENDING" && (
@@ -589,7 +553,6 @@ function ExerciseCard({
                     toast.error(t("errorDeletingExercise"), {
                       id: toastId,
                     });
-                    console.log(error);
                   }
                 }}
                 confirmationMessage={isEditing ? undefined : t("sure?")}

--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -434,7 +434,7 @@ function ExerciseCard({
   const current = getCurrentExercise();
   const isCurrent = current.slug === slug;
 
-  const isDone = TelemetryManager.isTesteable(position) && !TelemetryManager.hasPendingTasks(position);
+  const isDone = TelemetryManager.isTesteable(position) && TelemetryManager.isStepCompleted(position);
   const isTesteable = TelemetryManager.isTesteable(position);
   console.table({ graded, done, isDone, isTesteable });
 

--- a/src/managers/eventBus.ts
+++ b/src/managers/eventBus.ts
@@ -11,6 +11,7 @@ type Events = {
     score: number;
   };
   last_lesson_finished: {};
+  lesson_rendered: { stepPosition: number };
 };
 
 export const eventBus: Emitter<Events> = mitt<Events>();

--- a/src/managers/eventListener.tsx
+++ b/src/managers/eventListener.tsx
@@ -26,6 +26,11 @@ export default function EventListener() {
             console.debug("last_lesson_finished");
             // Verify again if there are pending tasks in any lesson
             if (!TelemetryManager.hasPendingTasksInAnyLesson()) {
+                // Mark the last step as complete if it hasn't been yet.
+                // quiz_submission / case "test" handle testeable steps; this covers
+                // read-only last steps that have no departure open_step event.
+                const lastPos = exercises.length - 1;
+                TelemetryManager.completeStepIfReadOnly(lastPos);
                 Notifier.confetti();
                 setOpenedModals({ lastLessonFinished: true });
             } else {

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -713,6 +713,7 @@ interface ITelemetryManager {
     language?: string
   ) => void;
   hasTesteableElementByHash: (stepPosition: number, hash: string) => boolean;
+  completeStepIfReadOnly: (stepPosition: number) => void;
   hasPendingTasks: (stepPosition: number) => boolean;
   hasPendingTasksInAnyLesson: () => boolean;
   isTesteable: (stepPosition: number) => boolean;
@@ -1008,6 +1009,30 @@ const TelemetryManager: ITelemetryManager = {
     this.save();
   },
 
+  /**
+   * Mark a step as completed if it has no testeable content (reading-only).
+   *
+   * Called from fetchSingleExerciseInfo once it has resolved the exercise's
+   * actual graded/testeable status.  This is the safe moment to auto-complete
+   * a step — open_step fires too early (before elements are registered) and
+   * cannot distinguish a reading-only step from one whose elements haven't
+   * loaded yet.
+   */
+  completeStepIfReadOnly: function (stepPosition: number) {
+    if (!this.current) return;
+    const step = this.current.steps[stepPosition];
+    if (!step || step.completed_at) return;
+
+    // If the step has any testeable_elements at this point (e.g. quiz elements
+    // restored from a previous session), it is NOT read-only.
+    if (step.testeable_elements?.length) return;
+
+    step.completed_at = Date.now();
+    step.is_completed = true;
+    this.current.steps[stepPosition] = step;
+    this.save();
+  },
+
   isTesteable: function (stepPosition: number) {
     const step = this.current?.steps[stepPosition];
     if (!step) {
@@ -1095,8 +1120,6 @@ const TelemetryManager: ITelemetryManager = {
         if (!hasPendingTasks && !step.completed_at && data.exit_code === 0) {
           step.completed_at = now;
           step.is_completed = true;
-        } else {
-          console.log("hasPendingTasks", hasPendingTasks);
         }
 
         this.current.steps[stepPosition] = step;
@@ -1127,9 +1150,6 @@ const TelemetryManager: ITelemetryManager = {
         ) {
           step.completed_at = now;
           step.is_completed = true;
-        } else {
-          console.log("hasPendingTasks", hasPendingTasks);
-          console.log("step.testeable_elements", step.testeable_elements);
         }
 
         this.current.steps[stepPosition] = step;
@@ -1144,27 +1164,44 @@ const TelemetryManager: ITelemetryManager = {
           typeof this.prevStep === "number" &&
           typeof this.prevStepStartedAt === "number"
         ) {
-          const prevStep = this.current.steps[this.prevStep];
+          const prevStepData = this.current.steps[this.prevStep];
           const delta = now - this.prevStepStartedAt;
 
-          if (!prevStep.sessions) prevStep.sessions = [];
-          prevStep.sessions.push(delta);
-          this.current.steps[this.prevStep] = prevStep;
+          if (!prevStepData.sessions) prevStepData.sessions = [];
+          prevStepData.sessions.push(delta);
+          this.current.steps[this.prevStep] = prevStepData;
         }
 
-        // Only complete the previous step when actually navigating to a DIFFERENT
-        // step. If prevStep === stepPosition (same-step re-navigation — e.g., from
-        // getOrCreateActiveSession or a double startTelemetry call) skip this block
-        // entirely: completing the step we are already on based on "leaving" it is
-        // semantically wrong and produces false is_completed=true on initial load.
-        if (typeof this.prevStep === "number" && this.prevStep !== stepPosition) {
-          const prevStep = this.current.steps[this.prevStep];
-
-          const hasPendingTasks = this.hasPendingTasks(this.prevStep);
-          if (!hasPendingTasks && !prevStep.completed_at) {
-            prevStep.completed_at = now;
-            prevStep.is_completed = true;
-            this.current.steps[this.prevStep] = prevStep;
+        // Auto-complete the PREVIOUS step on departure.
+        //
+        // When open_step(B) fires, step A (prevStep) has been fully rendered:
+        // quiz useEffects have run and testeable_elements is fully populated.
+        // hasPendingTasks(A) is therefore reliable.
+        //
+        // We do NOT auto-complete the CURRENT step (B) here: fetchSingleExerciseInfo
+        // is async and quiz useEffects haven't run yet, so testeable_elements for B
+        // is always empty at this point — any hasPendingTasks check would be wrong.
+        //
+        // Guards:
+        //   prevStep !== stepPosition   → skip same-step re-navigation (Bug A)
+        //   !prev.completed_at          → already completed by test/quiz, no-op
+        //   testeableButNotLoaded       → is_testeable=true but no elements registered
+        //                                 means fetchSingleExerciseInfo is still in
+        //                                 flight for a code-test step — skip
+        //   !hasPendingTasks(prevStep)  → all elements done (or step is read-only)
+        if (
+          typeof this.prevStep === "number" &&
+          this.prevStep !== stepPosition
+        ) {
+          const prev = this.current.steps[this.prevStep];
+          if (prev && !prev.completed_at) {
+            const testeableButNotLoaded =
+              prev.is_testeable && !prev.testeable_elements?.length;
+            if (!testeableButNotLoaded && !this.hasPendingTasks(this.prevStep)) {
+              prev.is_completed = true;
+              prev.completed_at = now;
+              this.current.steps[this.prevStep] = prev;
+            }
           }
         }
 
@@ -1175,20 +1212,6 @@ const TelemetryManager: ITelemetryManager = {
 
         this.prevStep = stepPosition;
         this.prevStepStartedAt = now;
-        // Auto-complete the last step only when it has no testeable exercises.
-        // If is_testeable is true, testeable_elements may not be registered yet at
-        // this point (fetchSingleExerciseInfo is async), so hasPendingTasks would
-        // return false even though there are pending tasks — causing a false completion.
-        // Testeable last steps complete through the normal test/quiz paths instead.
-        if (
-          stepPosition === this.current.steps.length - 1 &&
-          !step.is_testeable &&
-          !this.hasPendingTasks(stepPosition)
-        ) {
-          step.is_completed = true;
-          step.completed_at = now;
-          this.current.steps[stepPosition] = step;
-        }
 
         this.submit();
         break;

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1249,10 +1249,9 @@ const TelemetryManager: ITelemetryManager = {
     if (!this.current || !this.current.steps) {
       return false;
     }
-    
-    // Verify if any step has pending tasks
-    return this.current.steps.some((_, index) => 
-      this.hasPendingTasks(index)
+    return this.current.steps.some(
+      (step) =>
+        (step.is_testeable || step.testeable_elements?.length) && !step.is_completed
     );
   },
 

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -706,14 +706,17 @@ interface ITelemetryManager {
     data: any,
     retry?: number
   ) => void;
+  activeHashes: Map<string, Set<string>>;
   registerTesteableElement: (
     stepPosition: number,
-    testeableElement: TTesteableElement
+    testeableElement: TTesteableElement,
+    language?: string
   ) => void;
   hasTesteableElementByHash: (stepPosition: number, hash: string) => boolean;
   hasPendingTasks: (stepPosition: number) => boolean;
   hasPendingTasksInAnyLesson: () => boolean;
   isTesteable: (stepPosition: number) => boolean;
+  isStepCompleted: (stepPosition: number) => boolean;
   getStepIndicators: (stepPosition: number) => TStepIndicators | null;
   streamEvent: (stepPosition: number, event: string, data: any) => void;
   submit: () => Promise<void>;
@@ -731,6 +734,7 @@ const TelemetryManager: ITelemetryManager = {
   agent: "cloud",
   prevStep: undefined,
   prevStepStartedAt: undefined,
+  activeHashes: new Map<string, Set<string>>(),
   user: {
     token: "",
     rigo_token: "",
@@ -746,6 +750,7 @@ const TelemetryManager: ITelemetryManager = {
   },
 
   start: function (agent, steps, tutorialSlug, storageKey, student) {
+    this.activeHashes = new Map<string, Set<string>>();
     this.telemetryKey = storageKey;
     this.tutorialSlug = tutorialSlug;
     this.agent = agent;
@@ -949,14 +954,12 @@ const TelemetryManager: ITelemetryManager = {
 
   registerTesteableElement: function (
     stepPosition: number,
-    testeableElement: TTesteableElement
+    testeableElement: TTesteableElement,
+    language?: string
   ) {
     if (!this.current) {
-      console.log("No current telemetry to register testeable element", stepPosition, testeableElement);
       return
-    };
-
-    console.log("Registering testeable element", stepPosition, testeableElement);
+    }
 
     // Chequea si el elemento ya existe en otro step
     const existsInOtherStep = this.current.steps.findIndex(
@@ -966,7 +969,6 @@ const TelemetryManager: ITelemetryManager = {
     );
 
     if (existsInOtherStep !== -1) {
-      console.log(`Testeable element already exists in at ${existsInOtherStep} step, moving on to current step`, stepPosition, testeableElement);
       const otherStep = this.current.steps[existsInOtherStep];
       // remove from other step
       otherStep.testeable_elements = otherStep.testeable_elements?.filter((e) => e.hash !== testeableElement.hash);
@@ -994,8 +996,15 @@ const TelemetryManager: ITelemetryManager = {
     elements.push(newElement);
 
     step.testeable_elements = elements;
-    console.log("step.testeable_elements", step.testeable_elements);
     this.current.steps[stepPosition] = step;
+
+    if (testeableElement.type === "quiz" && language) {
+      if (!this.activeHashes.has(language)) {
+        this.activeHashes.set(language, new Set());
+      }
+      this.activeHashes.get(language)!.add(testeableElement.hash);
+    }
+
     this.save();
   },
 
@@ -1205,11 +1214,35 @@ const TelemetryManager: ITelemetryManager = {
 
   hasPendingTasks: function (stepPosition: number) {
     const step = this.current?.steps[stepPosition];
+    if (!step?.testeable_elements?.length) return false;
 
-    if (!step) {
-      return false;
+    // Tests are language-independent: if any is incomplete, the step is not done
+    const hasIncompleteTests = step.testeable_elements.some(
+      (e) => e.type === "test" && !e.is_completed
+    );
+    if (hasIncompleteTests) return true;
+
+    // Quizzes: the step is done if ALL active elements of at least one language are completed
+    const quizElements = step.testeable_elements.filter((e) => e.type === "quiz");
+    if (quizElements.length === 0) return false;
+
+    for (const [, hashes] of this.activeHashes) {
+      const relevantHashes = [...hashes].filter((h) =>
+        quizElements.some((e) => e.hash === h)
+      );
+      if (relevantHashes.length === 0) continue;
+
+      const allDone = relevantHashes.every(
+        (hash) => quizElements.find((e) => e.hash === hash)?.is_completed === true
+      );
+      if (allDone) return false;
     }
-    return Boolean(step.testeable_elements?.some((e) => !e.is_completed));
+
+    return true;
+  },
+
+  isStepCompleted: function (stepPosition: number) {
+    return this.current?.steps[stepPosition]?.is_completed ?? false;
   },
 
   hasPendingTasksInAnyLesson: function () {

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -529,6 +529,51 @@ function normalizeWorkoutSession(raw: unknown, now: number): TWorkoutSession[] {
 }
 
 /**
+ * Merges stored step activity into the current exercise structure.
+ * freshSteps is the canonical source for slug, position, files, and is_testeable.
+ * storedSteps provides accumulated activity (tests, compilations, etc.) matched by slug.
+ * Steps in storedSteps with no matching slug in freshSteps are silently dropped.
+ *
+ * If an exercise's slug is renamed by the instructor, the stored step will have no
+ * match in freshSteps (old slug is gone) and the new slug will have no match in
+ * storedSteps (never seen before). The result is a clean step with no prior activity,
+ * indistinguishable from a brand-new exercise. This is an accepted trade-off: the slug
+ * is the stable identity of an exercise, and renaming it is treated the same as
+ * deleting and recreating it.
+ */
+function mergeSteps(freshSteps: TStep[], storedSteps: TStep[]): TStep[] {
+  const storedBySlug = new Map<string, TStep>();
+  for (const s of storedSteps) {
+    if (s.slug) {
+      storedBySlug.set(s.slug, s);
+    }
+  }
+
+  return freshSteps.map((fresh) => {
+    const stored = storedBySlug.get(fresh.slug);
+    if (!stored) return fresh;
+
+    return {
+      // structural fields: always from freshSteps (current tutorial state)
+      slug: fresh.slug,
+      position: fresh.position,
+      files: fresh.files,
+      is_testeable: fresh.is_testeable,
+      // activity fields: preserved from stored blob
+      compilations: stored.compilations ?? [],
+      tests: stored.tests ?? [],
+      ai_interactions: stored.ai_interactions ?? [],
+      quiz_submissions: stored.quiz_submissions ?? [],
+      testeable_elements: stored.testeable_elements ?? [],
+      is_completed: stored.is_completed ?? false,
+      completed_at: stored.completed_at,
+      opened_at: stored.opened_at,
+      sessions: stored.sessions ?? [],
+    };
+  });
+}
+
+/**
  * Ensures telemetry matches ITelemetryJSONSchema and strips non-contract fields from server/local blobs.
  */
 export function normalizeTelemetrySchema(
@@ -561,7 +606,7 @@ export function normalizeTelemetrySchema(
       : now;
   const steps =
     Array.isArray(picked.steps) && picked.steps.length > 0
-      ? (picked.steps as TStep[])
+      ? mergeSteps(freshSteps, picked.steps as TStep[])
       : freshSteps;
   const workout_session = normalizeWorkoutSession(picked.workout_session, now);
   return {

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -12,7 +12,8 @@ import { LocalStorage } from "./localStorage";
 import axios, { AxiosResponse } from "axios";
 import { TAgent } from "../utils/storeTypes";
 import { LEARNPACK_LOCAL_URL } from "../utils/creator";
-import { RIGOBOT_HOST } from "../utils/lib";
+import { debounce, RIGOBOT_HOST } from "../utils/lib";
+import { eventBus } from "./eventBus";
 
 export interface IFile {
   path: string;
@@ -714,6 +715,8 @@ interface ITelemetryManager {
   ) => void;
   hasTesteableElementByHash: (stepPosition: number, hash: string) => boolean;
   completeStepIfReadOnly: (stepPosition: number) => void;
+  onLessonRendered: (stepPosition: number) => void;
+  _lessonRenderedDebounce: ReturnType<typeof debounce> | null;
   hasPendingTasks: (stepPosition: number) => boolean;
   hasPendingTasksInAnyLesson: () => boolean;
   isTesteable: (stepPosition: number) => boolean;
@@ -736,6 +739,7 @@ const TelemetryManager: ITelemetryManager = {
   prevStep: undefined,
   prevStepStartedAt: undefined,
   activeHashes: new Map<string, Set<string>>(),
+  _lessonRenderedDebounce: null,
   user: {
     token: "",
     rigo_token: "",
@@ -1027,10 +1031,40 @@ const TelemetryManager: ITelemetryManager = {
     // restored from a previous session), it is NOT read-only.
     if (step.testeable_elements?.length) return;
 
+    // If the step has code tests, it is NOT read-only.
+    if (step.is_testeable) return;
+
     step.completed_at = Date.now();
     step.is_completed = true;
     this.current.steps[stepPosition] = step;
     this.save();
+  },
+
+  /**
+   * Called (via eventBus "lesson_rendered") after the markdown content has
+   * rendered in the browser.  A debounce of 3 seconds gives quiz/FITB/OQ
+   * components time to mount and register their testeable_elements.  If
+   * after the debounce the step still has no testeable_elements and is not
+   * a code-test step, it is genuinely read-only and can be completed.
+   *
+   * The debounce is cancelled every time a new lesson_rendered fires (e.g.
+   * the user navigated to another step), so stale completions are avoided.
+   */
+  onLessonRendered: function (stepPosition: number) {
+    if (!this.current) return;
+
+    // Cancel any pending debounce from a previous step/render.
+    if (this._lessonRenderedDebounce) {
+      this._lessonRenderedDebounce.cancel();
+    }
+
+    const READOLY_COMPLETION_DELAY_MS = 7000;
+
+    this._lessonRenderedDebounce = debounce(() => {
+      this.completeStepIfReadOnly(stepPosition);
+    }, READOLY_COMPLETION_DELAY_MS);
+
+    this._lessonRenderedDebounce();
   },
 
   isTesteable: function (stepPosition: number) {
@@ -1172,36 +1206,30 @@ const TelemetryManager: ITelemetryManager = {
           this.current.steps[this.prevStep] = prevStepData;
         }
 
-        // Auto-complete the PREVIOUS step on departure.
+        // Auto-complete the PREVIOUS step on departure, but ONLY when
+        // testeable_elements already exist and all are done. This is a
+        // safety-net for steps whose quiz_submission / test handlers
+        // already set is_completed — it catches edge cases where the
+        // handler couldn't confirm completion at the time.
         //
-        // When open_step(B) fires, step A (prevStep) has been fully rendered:
-        // quiz useEffects have run and testeable_elements is fully populated.
-        // hasPendingTasks(A) is therefore reliable.
-        //
-        // We do NOT auto-complete the CURRENT step (B) here: fetchSingleExerciseInfo
-        // is async and quiz useEffects haven't run yet, so testeable_elements for B
-        // is always empty at this point — any hasPendingTasks check would be wrong.
-        //
-        // Guards:
-        //   prevStep !== stepPosition   → skip same-step re-navigation (Bug A)
-        //   !prev.completed_at          → already completed by test/quiz, no-op
-        //   testeableButNotLoaded       → is_testeable=true but no elements registered
-        //                                 means fetchSingleExerciseInfo is still in
-        //                                 flight for a code-test step — skip
-        //   !hasPendingTasks(prevStep)  → all elements done (or step is read-only)
+        // Steps with empty testeable_elements are NOT completed here.
+        // Read-only steps are completed via the "lesson_rendered" event
+        // handled by onLessonRendered(), which fires after the markdown
+        // has rendered and quiz components have had time to register.
         if (
           typeof this.prevStep === "number" &&
           this.prevStep !== stepPosition
         ) {
           const prev = this.current.steps[this.prevStep];
-          if (prev && !prev.completed_at) {
-            const testeableButNotLoaded =
-              prev.is_testeable && !prev.testeable_elements?.length;
-            if (!testeableButNotLoaded && !this.hasPendingTasks(this.prevStep)) {
-              prev.is_completed = true;
-              prev.completed_at = now;
-              this.current.steps[this.prevStep] = prev;
-            }
+          if (
+            prev &&
+            !prev.completed_at &&
+            prev.testeable_elements?.length &&
+            !this.hasPendingTasks(this.prevStep)
+          ) {
+            prev.is_completed = true;
+            prev.completed_at = now;
+            this.current.steps[this.prevStep] = prev;
           }
         }
 
@@ -1378,5 +1406,10 @@ export function submitTelemetryToRigobotViaBeacon(): void {
     TelemetryManager.user.rigo_token
   );
 }
+
+// Wire up the lesson_rendered event once, at module load time.
+eventBus.on("lesson_rendered", ({ stepPosition }) => {
+  TelemetryManager.onLessonRendered(stepPosition);
+});
 
 export default TelemetryManager;

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -75,47 +75,8 @@ const sendBatchTelemetryRigobot = async function (body: object, token: string) {
 };
 
 const FETCH_TELEMETRY_TIMEOUT_MS = 5000;
-const RESOLVE_PACKAGE_ID_TIMEOUT_MS = 5000;
 /** Idle threshold for refreshing telemetry from server when tab becomes visible again */
 export const TELEMETRY_VISIBILITY_REFRESH_IDLE_MS = 5 * 60 * 1000;
-
-const getRigobotPackageIdBySlug = async function (
-  packageSlug: string,
-  token: string
-): Promise<number | string | null> {
-  if (!packageSlug || !token) return null;
-
-  const cleanToken = token.trim();
-  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/`;
-
-  try {
-    const response: AxiosResponse<any> = await axios.get(url, {
-      headers: {
-        Authorization: `Token ${cleanToken}`,
-      },
-    });
-
-    return response?.data?.id ?? null;
-  } catch (error) {
-    // Best-effort enrichment, never block telemetry start/submit
-    console.warn("Unable to resolve Rigobot package_id", {
-      packageSlug,
-      error,
-    });
-    return null;
-  }
-};
-
-function resolvePackageIdWithTimeout(
-  packageSlug: string,
-  token: string,
-  ms: number
-): Promise<number | string | null> {
-  return Promise.race([
-    getRigobotPackageIdBySlug(packageSlug, token),
-    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
-  ]);
-}
 
 export type TTelemetryFetchResponse = {
   results?: unknown[];
@@ -128,18 +89,11 @@ export type TTelemetryFetchResponse = {
  */
 export async function fetchTelemetryFromServer(params: {
   userId: string;
-  packageId: number | string | null;
   packageSlug: string;
   rigoToken: string;
 }): Promise<ITelemetryJSONSchema | null> {
-  const { userId, packageId, packageSlug, rigoToken } = params;
-  if (
-    !userId ||
-    !rigoToken ||
-    !packageSlug ||
-    packageId == null ||
-    packageId === ""
-  ) {
+  const { userId, packageSlug, rigoToken } = params;
+  if (!userId || !rigoToken || !packageSlug) {
     return null;
   }
 
@@ -149,7 +103,6 @@ export async function fetchTelemetryFromServer(params: {
   search.set("include_buffer", "true");
   search.set("include_steps", "true");
   search.set("package_slug", packageSlug);
-  search.set("package_ids", String(packageId));
 
   const url = `${RIGOBOT_HOST}/v1/learnpack/telemetry?${search.toString()}`;
   const controller = new AbortController();
@@ -173,10 +126,6 @@ export async function fetchTelemetryFromServer(params: {
     const data = (await response.json()) as TTelemetryFetchResponse;
     const first = data?.results?.[0] as ITelemetryJSONSchema | undefined;
     if (!first || typeof first !== "object") {
-      return null;
-    }
-    if (first.slug && first.slug !== packageSlug) {
-      console.warn("fetchTelemetryFromServer: slug mismatch, ignoring");
       return null;
     }
     return first;
@@ -219,9 +168,7 @@ export function reconcileTelemetry(
   agent: TAgent,
   appVersion: string
 ): { telemetry: ITelemetryJSONSchema; source: TReconcileSource } {
-  const hasServer =
-    serverTelemetry &&
-    (!serverTelemetry.slug || serverTelemetry.slug === tutorialSlug);
+  const hasServer = !!serverTelemetry;
   const hasLocal =
     localTelemetry && localTelemetry.slug === tutorialSlug;
 
@@ -599,10 +546,7 @@ export function normalizeTelemetrySchema(
     }
   }
   const now = Date.now();
-  const slug =
-    typeof picked.slug === "string" && picked.slug.trim() !== ""
-      ? picked.slug
-      : tutorialSlug;
+  const slug = tutorialSlug;
   const version =
     typeof picked.version === "string" && picked.version.trim() !== ""
       ? picked.version
@@ -774,25 +718,7 @@ const TelemetryManager: ITelemetryManager = {
       this.reconciling = true;
       return (async () => {
         try {
-          let packageId: number | string | null = null;
-          if (student.rigo_token && tutorialSlug) {
-            packageId = await resolvePackageIdWithTimeout(
-              tutorialSlug,
-              student.rigo_token,
-              RESOLVE_PACKAGE_ID_TIMEOUT_MS
-            );
-          }
-
           const localRaw = LocalStorage.get(this.telemetryKey);
-          if (
-            packageId == null &&
-            localRaw &&
-            localRaw.slug === tutorialSlug &&
-            localRaw.package_id
-          ) {
-            packageId = localRaw.package_id;
-          }
-
           const localTelemetry =
             localRaw && localRaw.slug === tutorialSlug ? localRaw : null;
 
@@ -800,7 +726,6 @@ const TelemetryManager: ITelemetryManager = {
           if (student.rigo_token && student.user_id) {
             serverTelemetry = await fetchTelemetryFromServer({
               userId: student.user_id,
-              packageId,
               packageSlug: tutorialSlug,
               rigoToken: student.rigo_token,
             });
@@ -823,25 +748,6 @@ const TelemetryManager: ITelemetryManager = {
 
           if (!this.current.version) {
             this.current.version = `CLOUD:${this.version}`;
-          }
-
-          if (!this.current.package_id && packageId) {
-            this.current.package_id = packageId;
-          } else if (
-            !this.current.package_id &&
-            this.current.slug &&
-            this.user.rigo_token
-          ) {
-            getRigobotPackageIdBySlug(this.current.slug, this.user.rigo_token)
-              .then((resolvedId) => {
-                if (!resolvedId || !this.current) return;
-                if (this.current.package_id) return;
-                this.current.package_id = resolvedId;
-                this.save();
-              })
-              .catch((error) => {
-                console.error("Error getting Rigobot package id by slug", error);
-              });
           }
 
           this.finishWorkoutSession();
@@ -921,23 +827,6 @@ const TelemetryManager: ITelemetryManager = {
           this.current.version = `CLOUD:${this.version}`;
         }
 
-        if (
-          !this.current.package_id &&
-          this.current.slug &&
-          this.user.rigo_token
-        ) {
-          getRigobotPackageIdBySlug(this.current.slug, this.user.rigo_token)
-            .then((packageId) => {
-              if (!packageId || !this.current) return;
-              if (this.current.package_id) return;
-              this.current.package_id = packageId;
-              this.save();
-            })
-            .catch((error) => {
-              console.error("Error getting Rigobot package id by slug", error);
-            });
-        }
-
         this.save();
 
         this.started = true;
@@ -975,14 +864,10 @@ const TelemetryManager: ITelemetryManager = {
 
     const server = await fetchTelemetryFromServer({
       userId: this.user.id,
-      packageId: this.current.package_id ?? null,
       packageSlug: this.tutorialSlug,
       rigoToken: this.user.rigo_token,
     });
     if (!server) {
-      return;
-    }
-    if (server.slug && server.slug !== this.tutorialSlug) {
       return;
     }
     const serverTs = server.last_interaction_at ?? 0;

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1170,7 +1170,16 @@ const TelemetryManager: ITelemetryManager = {
 
         this.prevStep = stepPosition;
         this.prevStepStartedAt = now;
-        if (stepPosition === this.current.steps.length - 1 && !this.hasPendingTasks(stepPosition)) {
+        // Auto-complete the last step only when it has no testeable exercises.
+        // If is_testeable is true, testeable_elements may not be registered yet at
+        // this point (fetchSingleExerciseInfo is async), so hasPendingTasks would
+        // return false even though there are pending tasks — causing a false completion.
+        // Testeable last steps complete through the normal test/quiz paths instead.
+        if (
+          stepPosition === this.current.steps.length - 1 &&
+          !step.is_testeable &&
+          !this.hasPendingTasks(stepPosition)
+        ) {
           step.is_completed = true;
           step.completed_at = now;
           this.current.steps[stepPosition] = step;

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1152,7 +1152,12 @@ const TelemetryManager: ITelemetryManager = {
           this.current.steps[this.prevStep] = prevStep;
         }
 
-        if (typeof this.prevStep === "number") {
+        // Only complete the previous step when actually navigating to a DIFFERENT
+        // step. If prevStep === stepPosition (same-step re-navigation — e.g., from
+        // getOrCreateActiveSession or a double startTelemetry call) skip this block
+        // entirely: completing the step we are already on based on "leaving" it is
+        // semantically wrong and produces false is_completed=true on initial load.
+        if (typeof this.prevStep === "number" && this.prevStep !== stepPosition) {
           const prevStep = this.current.steps[this.prevStep];
 
           const hasPendingTasks = this.hasPendingTasks(this.prevStep);

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -1037,6 +1037,7 @@ The user's set up the application in "${language}" language, give your feedback 
       setFeedbackButtonProps,
       checkParams,
       registerTelemetryEvent,
+      telemetryReady,
       updateDBSession,
     } = get();
 
@@ -1058,9 +1059,17 @@ The user's set up the application in "${language}" language, give your feedback 
       }
     });
 
-    registerTelemetryEvent("open_step", {
-      step_position: newPosition,
-    });
+    // Only register open_step if telemetry is already initialized. When setPosition
+    // is called during app init (e.g. from checkParams before startTelemetry runs),
+    // TelemetryManager.current is null and the event would be queued as a retry.
+    // That retry fires ~2s later with prevStep already set, incorrectly marking the
+    // step as is_completed=true. startTelemetry() registers the initial open_step
+    // itself once the manager is ready.
+    if (telemetryReady) {
+      registerTelemetryEvent("open_step", {
+        step_position: newPosition,
+      });
+    }
     fetchReadme();
     setTimeout(updateDBSession, 5000);
   },


### PR DESCRIPTION
⚠️ Requiere [Refactor/improve telemetry management](https://github.com/breatheco-de/rigobot/pull/368) en producción (rigobot)

---

**Soluciona tres grupos de problemas en el sistema de telemetría del IDE**:

  - **Hashes huérfanos y cursos multiidioma**: hashes de quizzes de ediciones anteriores del contenido o de otros idiomas
  bloqueaban indefinidamente el botón Finish y el `completion_rate`. 
  Se reescribe `hasPendingTasks` para ignorar hashes no activos en la sesión (`activeHashes`).
Para dar por completado un step, se aplica lógica por idioma sobre `testeable_elements` de ese step: 

> - si todos los elementos de tipo "test" (igual en todos los idiomas) están completos **y**
> - si todos los elementos  de tipo "quiz" relacionados a al menos uno de los idiomas están completos

  el step se marca como completo (`step.is_completed: true`).

  - **Race conditions en carga inicial**: dos rutas concurrentes (`startTelemetry` + `getOrCreateActiveSession`, y
  `checkParams` + retry de 2s) disparaban `open_step` antes de que la telemetría estuviera lista, marcando lecciones como
  completadas sin acción del alumno. Se agrega guard `telemetryReady` en `setPosition`.

  - **Lecciones con quizzes marcadas como read-only**: ante navegación rápida (cuando el step no tiene `testeable_elements` poblado aún) no podía distinguir lecciones, el sistema podía completar la lección por considerarla **read-only** (por no tener elementos en `testeable_elements` aún). 
Para evitar race conditions entre la evaluación de step.testeable_elements.length y el registro de dichos elementos (que se realizan luego de traer markdown desde el servidor, renderizar componentes y creación y registro de hashes), se crea el evento `lesson_rendered` con debounce de 7s.
El evento `open_step` solo auto-completa si ya existen `testeable_elements`.
`completeStepIfReadOnly` se invoca solo cuando el contenido ha renderizado y no se registró ningún elemento testeable.