### PR TITLE
feat: show academy info in publish modal based on asset association mode

### DIFF
--- a/src/components/Creator/PublishButton.tsx
+++ b/src/components/Creator/PublishButton.tsx
@@ -6,7 +6,7 @@ import { svgs } from "../../assets/svgs";
 import { Modal } from "../mockups/Modal";
 import ProgressBar from "../composites/ProgressBar/ProgressBar";
 import useStore from "../../utils/store";
-import { publishTutorial, changeSlug, getUserAcademies, getPackageAcademy } from "../../utils/creator";
+import { publishTutorial, changeSlug, getUserAcademies, getPackageAcademy, PackageAcademyInfo } from "../../utils/creator";
 import { toast } from "react-hot-toast";
 import { playEffect, getSlugFromPath, slugify } from "../../utils/lib";
 import { Notifier } from "../../managers/Notifier";
@@ -38,8 +38,7 @@ const PublishConfirmationModal: FC<{
   const [academies, setAcademies] = useState<Academy[]>([]);
   const [selectedAcademyId, setSelectedAcademyId] = useState<number | undefined>(undefined);
   const [loadingAcademies, setLoadingAcademies] = useState(false);
-  const [packageAcademyId, setPackageAcademyId] = useState<number | null>(null);
-  const [isPublished, setIsPublished] = useState(false);
+  const [packageAcademyInfo, setPackageAcademyInfo] = useState<PackageAcademyInfo | null>(null);
   const [loadingPackageInfo, setLoadingPackageInfo] = useState(false);
 
   useEffect(() => {
@@ -62,22 +61,20 @@ const PublishConfirmationModal: FC<{
     if (!bcToken) return;
     const currentSlug = getSlugFromPath();
     if (!currentSlug) return;
-    
+
     try {
       setLoadingPackageInfo(true);
       const packageInfo = await getPackageAcademy(bcToken, currentSlug);
-      setPackageAcademyId(packageInfo.academyId);
-      setIsPublished(packageInfo.isPublished);
-      
-      // If package has an academy, use it automatically
-      if (packageInfo.academyId !== null) {
-        setSelectedAcademyId(packageInfo.academyId);
+      setPackageAcademyInfo(packageInfo);
+
+      // For locked mode, pre-set the academy so it's sent on publish
+      if (packageInfo.mode === "locked" && packageInfo.lockedAcademyId !== undefined) {
+        setSelectedAcademyId(packageInfo.lockedAcademyId);
       }
     } catch (error) {
       console.error("Error fetching package academy:", error);
-      // On error, assume not published so user can still select academy
-      setPackageAcademyId(null);
-      setIsPublished(false);
+      // On error, fall back to select mode so the user can still proceed
+      setPackageAcademyInfo({ isPublished: false, mode: "select" });
     } finally {
       setLoadingPackageInfo(false);
     }
@@ -132,8 +129,8 @@ const PublishConfirmationModal: FC<{
       setLoadingAcademies(true);
       const academiesList = await getUserAcademies(bcToken);
       setAcademies(academiesList);
-      // Auto-select if only one academy
-      if (academiesList.length === 1) {
+      // Auto-select only in select mode (no existing academy association)
+      if (academiesList.length === 1 && packageAcademyInfo?.mode !== "locked") {
         setSelectedAcademyId(academiesList[0].id);
       }
     } catch (error) {
@@ -213,14 +210,14 @@ const PublishConfirmationModal: FC<{
 
             <div className="flex-y gap-small padding-small">
               <label className="text-blue font-medium">{t("tutorial-slug")}</label>
-              <input 
+              <input
                 className="padding-small rounded border"
                 maxLength={47}
                 value={editableSlug}
                 onClick={(e) => e.stopPropagation()}
                 onChange={handleSlugChange}
                 placeholder={t("tutorial-slug")}
-                disabled={isPublished}
+                disabled={packageAcademyInfo?.isPublished}
               />
               <div className="flex-x justify-between align-center">
                 <span className="text-small text-gray-600">{editableSlug.length}/47</span>
@@ -234,14 +231,14 @@ const PublishConfirmationModal: FC<{
                   <span className="text-small text-danger">{t("slug-taken")}</span>
                 )}
               </div>
-              {isPublished && (
+              {packageAcademyInfo?.isPublished && (
                 <p className="text-small text-gray-600 m-0">
                   You can't change the slug in published packages
                 </p>
               )}
             </div>
 
-            {academies.length > 0 && !loadingPackageInfo && packageAcademyId === null && (
+            {!loadingPackageInfo && packageAcademyInfo?.mode === "select" && academies.length > 0 && (
               <div className="flex-y gap-small padding-small">
                 <label className="text-blue font-medium">Academy</label>
                 <select
@@ -258,6 +255,30 @@ const PublishConfirmationModal: FC<{
                     </option>
                   ))}
                 </select>
+              </div>
+            )}
+
+            {!loadingPackageInfo && packageAcademyInfo?.mode === "locked" && (
+              <div className="flex-y gap-small padding-small">
+                <label className="text-blue font-medium">Academy</label>
+                <p className="padding-small rounded border bg-soft-blue text-blue m-0">
+                  {academies.find((a) => a.id === packageAcademyInfo.lockedAcademyId)?.name
+                    ?? `Academy #${packageAcademyInfo.lockedAcademyId}`}
+                </p>
+                <p className="text-small text-gray-600 m-0">
+                  The academy cannot be changed for published packages.
+                </p>
+              </div>
+            )}
+
+            {!loadingPackageInfo && packageAcademyInfo?.mode === "conflict" && (
+              <div className="flex-y gap-small padding-small bg-soft-yellow rounded">
+                <p className="text-yellow font-medium m-0">⚠ Academy conflict</p>
+                <p className="text-small text-yellow m-0">
+                  Your assets are associated with different academies
+                  ({packageAcademyInfo.conflictAcademies?.join(", ")}).
+                  Academy assignment will be skipped.
+                </p>
               </div>
             )}
 

--- a/src/utils/creator.ts
+++ b/src/utils/creator.ts
@@ -80,10 +80,19 @@ export const getUserAcademies = async (breathecodeToken: string) => {
   }
 };
 
+export type PackageAcademyMode = "select" | "locked" | "conflict";
+
+export type PackageAcademyInfo = {
+  isPublished: boolean;
+  mode: PackageAcademyMode;
+  lockedAcademyId?: number;
+  conflictAcademies?: number[];
+};
+
 export const getPackageAcademy = async (
   breathecodeToken: string,
   slug: string
-): Promise<{ academyId: number | null; isPublished: boolean }> => {
+): Promise<PackageAcademyInfo> => {
   try {
     const headers = {
       "x-breathecode-token": breathecodeToken,


### PR DESCRIPTION
⚠️ Require este PR de CLI: [refactor: filter listUserAcademies by crud_asset capability per academy](https://github.com/learnpack/learnpack-cli/pull/194)

---

- Replace packageAcademyId state with full PackageAcademyInfo (mode, lockedAcademyId, conflictAcademies)
- Show read-only academy name when mode is locked (assets already associated to an academy)
- Show conflict warning when assets belong to different academies
- Academy selector only shown in select mode (asset with no prior association)