### PR TITLE
Feat/add asset ids to Breathecode telemetry

### DIFF
--- a/.agents/skills/telemetry/SKILL.md
+++ b/.agents/skills/telemetry/SKILL.md
@@ -33,8 +33,16 @@ TelemetryManager (singleton)       ← src/managers/telemetry.ts
     │  accumulates in .current (in memory)
     ├─ save() → localStorage["TELEMETRY"]   (cloud agent)
     ├─ save() → POST /telemetry             (os/vscode agents)
-    └─ submit() → POST Rigobot + Breathecode
+    └─ submit() → POST Breathecode (batch URL) then POST Rigobot (same JSON body)
 ```
+
+### Batch vs streaming
+
+**Student progress is carried by the batch blob**, not by the streaming channel.
+
+- Every `registerStepEvent()` updates `TelemetryManager.current`, then **`save()`** (localStorage or CLI file).
+- **`submit()`** sends the **full blob** to **`config.telemetry.batch`** (Breathecode) and to **Rigobot** (`/v1/learnpack/telemetry`).
+- **`config.telemetry.streaming`** is **optional**. Default LearnPack templates often define only `telemetry.batch`. If `streaming` is missing, `streamEvent()` returns immediately and **no** per-event HTTP firehose runs — the student’s work is still recorded via **`save()`** and **batch `submit()`**.
 
 ### The IDE as source of truth for step structure (cloud)
 
@@ -86,39 +94,45 @@ signal used by `onLessonRendered` to detect read-only steps (see below).
 
 ## How to register a new event
 
-1. Call `TelemetryManager.registerStepEvent(eventType, data)` from the component/store
+1. Call `TelemetryManager.registerStepEvent(stepPosition, eventType, data)` from the component/store (via `registerTelemetryEvent` in the store)
 2. The event is appended to the corresponding array in `TelemetryManager.current.steps[n]`
 3. `save()` is called automatically after each registration
 4. Add the new type to `TStep` (see `references/schema.md`)
 
-For compilation/test events, data must be base64-encoded:
-```typescript
-// telemetry.ts:386-391
-const encode = (s: string) => btoa(encodeURIComponent(s))
-```
+For compilation/test events, data must be base64-encoded (see `stringToBase64` / `fixStepData` in `src/managers/telemetry.ts`).
 
 ## Lifecycle and submission triggers
 
-**Bootstrap** (on IDE startup):
-1. Resolve `package_id` from slug — 5s timeout
-2. `GET ${RIGOBOT_HOST}/v1/learnpack/telemetry?include_buffer=true` — 5s timeout
-3. Load from `localStorage`
-4. Reconcile (see Reconciliation section)
-5. If source is `"local"`, submit immediately
+**Bootstrap** (cloud agent — `TelemetryManager.start`):
+1. Load prior blob from `localStorage` (same tutorial slug only)
+2. `GET ${RIGOBOT_HOST}/v1/learnpack/telemetry?...` with `user_ids`, `package_slug`, `include_buffer=true`, `include_steps=true` — 5s timeout (`FETCH_TELEMETRY_TIMEOUT_MS`)
+3. `reconcileTelemetry()` (see Reconciliation section)
+4. Apply session fields (`user_id`, `fullname`, `cohort_id`, `academy_id`), `save()`, then if reconciliation source is `"local"`, **`submit()`** immediately
 
-**Automatic submissions** (`submit()` → Rigobot + Breathecode):
-- Test completes with `exit_code === 0`
-- Quiz submitted
-- Step opened
-- Tab hidden
-- Page closed — beacon with `keepalive: true`
+There is **no separate “resolve package_id” HTTP step** in this bootstrap path; `package_id` may appear inside stored or server blobs and is preserved when whitelisted.
+
+**`submit()` — dual batch POST (same body, strict order):**
+1. `POST` **`config.telemetry.batch`** with **Breathecode** token (`Authorization: Token <breathecode_token>`).
+2. If that succeeds, `POST` **`${RIGOBOT_HOST}/v1/learnpack/telemetry`** with **Rigobot** token.
+
+If the Breathecode POST **throws**, the Rigobot POST is **not** attempted (single `try` / sequential `await`).
+
+**When `submit()` runs** (non-exhaustive):
+- After **`test`** when `exit_code === 0` (and related completion logic)
+- After **`quiz_submission`**
+- After **`open_step`**
+- Cloud: when the tab becomes **hidden** (`visibilitychange` → `TelemetryManager.submit()`)
+
+**Page unload — Rigobot-only beacon:**
+
+On `beforeunload` / `pagehide` (cloud), `submitTelemetryToRigobotViaBeacon()` sends **one** `fetch` with **`keepalive: true`** to **Rigobot only**. It does **not** call the Breathecode batch URL. This is a best-effort last send when the page is tearing down; the hidden-tab `submit()` path is what reliably hits **both** backends during normal navigation.
 
 **Server refresh:**
-- On tab focus if idle > 5 minutes (`TELEMETRY_VISIBILITY_REFRESH_IDLE_MS`)
+- On tab focus if idle > 5 minutes (`TELEMETRY_VISIBILITY_REFRESH_IDLE_MS`) — refetch Rigobot telemetry and merge via `normalizeTelemetrySchema` when server `last_interaction_at` is newer
 
 ## Local ↔ server reconciliation
 
-Function: `reconcileTelemetry()` — `telemetry.ts:214-314`
+Function: `reconcileTelemetry()` — `src/managers/telemetry.ts` (`export function reconcileTelemetry`)
 
 Strategy: **"most recent `last_interaction_at` wins"**
 
@@ -389,7 +403,7 @@ last_interaction_at` if no `ended_at`) and opens a new one. Handled by
   of 3 attempts with 2s delay. Note: `open_step` is excluded from this retry mechanism
   via the `telemetryReady` guard in `setPosition`.
 
-- **Keys persisted in localStorage have a strict whitelist** (`telemetry.ts:539-555`) —
+- **Keys persisted in localStorage have a strict whitelist** (`TELEMETRY_WHITELIST_KEYS` in `src/managers/telemetry.ts`) —
   fields outside the whitelist are discarded during normalization.
 
 - **No HTTP retry**: if a POST fails, it is logged and discarded.

--- a/.agents/skills/telemetry/references/apis.md
+++ b/.agents/skills/telemetry/references/apis.md
@@ -62,9 +62,11 @@ Body: ITelemetryJSONSchema (full blob with computed metrics)
 
 ### GET /v1/learnpack/package/${slug}/
 
-**Purpose:** Package metadata on Rigobot (e.g. existence check for authors).
+**Purpose:** Package metadata on Rigobot (e.g. `asset_ids`, existence check for authors).
 
-**Used in:** `src/utils/apiCalls.ts` (`isPackageAuthor` — status 200 vs 404).
+**Used in:**
+
+- `src/utils/apiCalls.ts` — `isPackageAuthor` (status 200 vs 404); `fetchLearnpackPackageAssetIds()` parses `asset_ids` for telemetry batch (Breathecode query param only).
 
 ```
 GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
@@ -73,7 +75,7 @@ Headers:
   Authorization: Token <rigobot_token>
 ```
 
-Not part of the telemetry manager bootstrap; other features may call it as needed.
+During `TelemetryManager.start()` (cloud and local agents), the IDE loads `asset_ids` **once** via `fetchLearnpackPackageAssetIds` when `rigo_token` and package slug are present. IDs are kept in memory (`TelemetryManager.packageAssetIds`), not in the persisted telemetry blob.
 
 ---
 
@@ -83,7 +85,15 @@ Not part of the telemetry manager bootstrap; other features may call it as neede
 
 **Purpose:** Second destination for the **same** batch body as Rigobot (when `submit()` completes the Breathecode call).
 
-**Implementation:** `sendBatchTelemetryBreathecode()` in `src/managers/telemetry.ts`.
+**Implementation:** `sendBatchTelemetryBreathecode()` in `src/managers/telemetry.ts` (builds the final URL with `withAssetIdQuery()` when IDs are present).
+
+**Optional query string** (Breathecode only — not sent on Rigobot batch or on GET telemetry):
+
+```
+POST <config.telemetry.batch>?asset_id=<id>[,<id>...]
+```
+
+When `TelemetryManager.packageAssetIds` is non-empty (from Rigobot package `asset_ids`), the client appends `asset_id` as a comma-separated list. If the batch URL already contains a `?`, the param is joined with `&`. Empty or missing package record → no `asset_id` param (URL unchanged).
 
 ```
 POST <config.telemetry.batch>

--- a/.agents/skills/telemetry/references/apis.md
+++ b/.agents/skills/telemetry/references/apis.md
@@ -7,21 +7,24 @@ VITE_RIGOBOT_HOST     → https://rigobot.herokuapp.com  (default)
 VITE_BREATHECODE_HOST → https://breathecode.herokuapp.com  (default)
 ```
 
-The auth token comes from the user's session (Rigobot token).
+Batch requests use **two** tokens: Breathecode token on `telemetry.batch`, Rigobot token on `/v1/learnpack/telemetry`.
 
 ---
 
-## Rigobot — Primary endpoint
+## Rigobot — Primary read/write for the telemetry blob
 
 ### GET /v1/learnpack/telemetry
-**Purpose:** Fetch telemetry from the server on startup or refresh.
-**File:** `telemetry.ts:154`
+
+**Purpose:** Fetch the latest stored telemetry blob for reconciliation (cloud bootstrap and stale refresh).
+
+**Implementation:** `fetchTelemetryFromServer()` in `src/managers/telemetry.ts`.
+
+**Query string sent by the IDE** (no other params are added by this client today):
 
 ```
 GET ${RIGOBOT_HOST}/v1/learnpack/telemetry
   ?user_ids=<user_id>
   &package_slug=<slug>
-  &package_ids=<package_id>
   &include_buffer=true
   &include_steps=true
 
@@ -29,14 +32,17 @@ Headers:
   Authorization: Token <rigobot_token>
 ```
 
-Timeout: `FETCH_TELEMETRY_TIMEOUT_MS = 5000ms`
-Response: `ITelemetryJSONSchema | null`
+Timeout: `FETCH_TELEMETRY_TIMEOUT_MS` (5000ms). On failure or non-OK response, returns `null` and reconciliation falls back to local/new blob as appropriate.
+
+Response shape: JSON with a `results` array; the IDE uses `results[0]` as `ITelemetryJSONSchema | null`.
 
 ---
 
 ### POST /v1/learnpack/telemetry
-**Purpose:** Batch submission of the full blob.
-**File:** `telemetry.ts:59`
+
+**Purpose:** Batch submission of the full telemetry payload (same JSON as Breathecode batch).
+
+**Implementation:** `sendBatchTelemetryRigobot()` in `src/managers/telemetry.ts`.
 
 ```
 POST ${RIGOBOT_HOST}/v1/learnpack/telemetry
@@ -48,13 +54,17 @@ Headers:
 Body: ITelemetryJSONSchema (full blob with computed metrics)
 ```
 
-Also called with `keepalive: true` on `pagehide`/`beforeunload` (beacon).
+**Order relative to Breathecode:** Inside `TelemetryManager.submit()`, **Breathecode batch runs first**. Rigobot POST runs only if Breathecode does not throw.
+
+**Beacon on page unload:** `submitTelemetryToRigobotViaBeacon()` issues a **separate** `POST` with `fetch(..., { keepalive: true })` to this same path. It is **Rigobot only** — it does **not** POST to the Breathecode batch URL.
 
 ---
 
 ### GET /v1/learnpack/package/${slug}/
-**Purpose:** Resolve `package_id` from the package slug.
-**File:** `telemetry.ts:89`
+
+**Purpose:** Package metadata on Rigobot (e.g. existence check for authors).
+
+**Used in:** `src/utils/apiCalls.ts` (`isPackageAuthor` — status 200 vs 404).
 
 ```
 GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
@@ -63,35 +73,39 @@ Headers:
   Authorization: Token <rigobot_token>
 ```
 
-Timeout: `RESOLVE_PACKAGE_ID_TIMEOUT_MS = 5000ms`
-Response: `{ id: number, ... }`
+Not part of the telemetry manager bootstrap; other features may call it as needed.
 
 ---
 
-## Breathecode — Secondary endpoint
+## Breathecode — Batch mirror
 
-### POST (URL configured in the package)
-**Purpose:** Alternate batch submission, complementary to Rigobot.
-**File:** `telemetry.ts:23-56`
+### POST (URL from package config)
+
+**Purpose:** Second destination for the **same** batch body as Rigobot (when `submit()` completes the Breathecode call).
+
+**Implementation:** `sendBatchTelemetryBreathecode()` in `src/managers/telemetry.ts`.
 
 ```
-POST <config.batch_url>
+POST <config.telemetry.batch>
 
 Headers:
   Authorization: Token <breathecode_token>
   Content-Type: application/json
 
-Body: ITelemetryJSONSchema (same payload as Rigobot)
+Body: ITelemetryJSONSchema (same payload as Rigobot batch)
 ```
 
-The URL comes from `config.telemetry.batch` in the LearnPack package config.
+The base URL comes from `config.telemetry.batch` in the loaded LearnPack config (`learn.json` / cloud `config.json`). Local templates often set this to `https://breathecode.herokuapp.com/v1/assignment/me/telemetry` (exact string may vary by environment).
 
 ---
 
-## Streaming — Individual real-time events
+## Streaming — Optional per-event POSTs
 
-**Purpose:** Send individual events during the session (not batch).
-**File:** `telemetry.ts:1342-1362`
+**Purpose:** Fire **individual** step events (`compile`, `test`, `open_step`, etc.) to a separate endpoint **in addition to** the batch blob. **Not required** for progress: the batch path + `save()` holds authoritative step state.
+
+**Implementation:** `streamEvent()` → `sendStreamTelemetry()` in `src/managers/telemetry.ts`.
+
+If `config.telemetry.streaming` is **undefined**, `streamEvent()` returns immediately.
 
 ```
 POST <config.telemetry.streaming>
@@ -106,11 +120,13 @@ Body: {
 }
 ```
 
+**Auth note:** `sendStreamTelemetry` requires a non-empty token to run, but the current `fetch` call does **not** attach `Authorization` or embed the token in the body. If the streaming endpoint requires auth, that may need to be aligned in code.
+
 ---
 
 ## CLI — Local bridge (os/vscode agents)
 
-**File:** `telemetry.ts:361-384`
+**File:** `src/managers/telemetry.ts` (CLI URL helpers)
 
 ```
 GET http://localhost:<PORT>/telemetry
@@ -126,7 +142,7 @@ POST http://localhost:<PORT>/telemetry
 
 ## Error behavior
 
-- **Timeout** (package resolve or fetch): returns `null`, continues with local data
-- **4xx/5xx HTTP**: error is logged, Promise is rejected, **no retry**
-- **Tab closed**: beacon with `keepalive: true` — one-way, no delivery confirmation
-- **TelemetryManager not initialized**: retry loop of 3 attempts with 2s delay
+- **GET telemetry timeout / abort:** returns `null`, reconciliation continues with local or new state
+- **4xx/5xx on batch POST:** logged, `submit()` fails as a whole; Rigobot is skipped if Breathecode failed first
+- **Page close:** Rigobot `keepalive` beacon only — no delivery guarantee; Breathecode is not called on that path
+- **TelemetryManager not initialized** on first event: retry loop (3 attempts, 2s delay) for `registerStepEvent`; `open_step` is gated by `telemetryReady` separately

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -7,23 +7,24 @@ The heart of all telemetry logic in the IDE.
 
 | Lines (approx.) | Contents |
 |-----------------|----------|
-| 24-57 | `sendBatchTelemetryBreathecode()` |
-| 59-76 | `sendBatchTelemetryRigobot()` |
-| 91-143 | `fetchTelemetryFromServer()` |
-| 164-262 | `reconcileTelemetry()` |
-| 267-280 | `submitViaBeacon()` — used for Rigobot keepalive POSTs |
-| 283-306 | `sendStreamTelemetry()` |
-| 339+ | `stringToBase64` / encoding helpers used by `fixStepData` |
-| 424+ | `fixStepData()` — normalizes step event payloads |
-| 487+ | `TELEMETRY_WHITELIST_KEYS` — persisted blob whitelist |
-| 580+ | `normalizeTelemetrySchema()` |
-| 632+ | `buildSubmitPayload()` |
-| 757+ | `TelemetryManager.start()` — cloud vs os/vscode bootstrap |
-| 908+ | `refreshFromServerIfStale()` |
-| 1112+ | `registerStepEvent()` — mutates `current`, `submit()` / `save()` / `streamEvent()` |
-| 1323+ | `submit()` — Breathecode batch then Rigobot batch |
-| 1369+ | `streamEvent()` — optional streaming URL |
-| 1395+ | `submitTelemetryToRigobotViaBeacon()` — unload hook (Rigobot only) |
+| 25-31 | `withAssetIdQuery()` — appends `asset_id` to Breathecode batch URL |
+| 33+ | `sendBatchTelemetryBreathecode()` — optional `packageAssetIds` for Breathecode query |
+| (next) | `sendBatchTelemetryRigobot()` |
+| 103+ | `fetchTelemetryFromServer()` |
+| (next) | `reconcileTelemetry()` |
+| (next) | `submitViaBeacon()` — used for Rigobot keepalive POSTs |
+| (next) | `sendStreamTelemetry()` |
+| (next) | `stringToBase64` / encoding helpers used by `fixStepData` |
+| (next) | `fixStepData()` — normalizes step event payloads |
+| (next) | `TELEMETRY_WHITELIST_KEYS` — persisted blob whitelist |
+| (next) | `normalizeTelemetrySchema()` |
+| (next) | `buildSubmitPayload()` |
+| 772+ | `TelemetryManager.start()` — cloud vs os/vscode bootstrap; loads `packageAssetIds` |
+| (next) | `refreshFromServerIfStale()` |
+| (next) | `registerStepEvent()` — mutates `current`, `submit()` / `save()` / `streamEvent()` |
+| 1358+ | `submit()` — Breathecode batch (with `asset_id` query when set) then Rigobot batch |
+| (next) | `streamEvent()` — optional streaming URL |
+| (next) | `submitTelemetryToRigobotViaBeacon()` — unload hook (Rigobot only) |
 
 ---
 
@@ -86,6 +87,14 @@ The heart of all telemetry logic in the IDE.
 ### `src/managers/localStorage.ts`
 - `LocalStorage.set()` — sanitizer interception point
 - Telemetry key: `"TELEMETRY"`
+
+---
+
+## API helpers
+
+### `src/utils/apiCalls.ts`
+
+- `fetchLearnpackPackageAssetIds()` — GET Rigobot package, returns `asset_ids` as `number[]` for Breathecode batch URL (telemetry bootstrap).
 
 ---
 

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -5,79 +5,68 @@
 ### `src/managers/telemetry.ts`
 The heart of all telemetry logic in the IDE.
 
-| Lines | Contents |
-|-------|----------|
-| 1-50 | Timeout constants, imports, auxiliary types |
-| 23-56 | `sendBatchTelemetryBreathecode()` |
-| 58-75 | `sendBatchTelemetryRigobot()` |
-| 82-107 | `getRigobotPackageIdBySlug()` |
-| 129-193 | `fetchTelemetryFromServer()` |
-| 214-314 | `reconcileTelemetry()` — local/server reconciliation logic |
-| 386-391 | `encode()` / `decode()` — base64 for source code |
-| 539-555 | localStorage key whitelist |
-| 587-640 | `normalize()` — normalizes blob before saving |
-| 649 | Metrics and indicators computation in `submit()` |
-| 759-870 | `TelemetryManager.start()` — full bootstrap |
-| 859 | Auto-submit when source is "local" |
-| 964-1007 | `refreshFromServerIfStale()` |
-| 1061 | `open_step` registration in store |
-| 1114-1124 | Event registration retry loop (3 attempts, 2s) |
-| 1164 | Submit on test complete with exit_code === 0 |
-| 1197 | Submit on quiz submitted |
-| 1212 | Session duration registration |
-| 1234 | Complete last step of the course |
-| 1240 | Submit on step opened |
-| 1250 | `save()` after each event |
-| 1296-1324 | `submit()` — batch send to Rigobot + Breathecode |
-| 1332 | Sync to CLI when agent is os/vscode |
-| 1342-1362 | `streamEvent()` — individual streaming |
+| Lines (approx.) | Contents |
+|-----------------|----------|
+| 24-57 | `sendBatchTelemetryBreathecode()` |
+| 59-76 | `sendBatchTelemetryRigobot()` |
+| 91-143 | `fetchTelemetryFromServer()` |
+| 164-262 | `reconcileTelemetry()` |
+| 267-280 | `submitViaBeacon()` — used for Rigobot keepalive POSTs |
+| 283-306 | `sendStreamTelemetry()` |
+| 339+ | `stringToBase64` / encoding helpers used by `fixStepData` |
+| 424+ | `fixStepData()` — normalizes step event payloads |
+| 487+ | `TELEMETRY_WHITELIST_KEYS` — persisted blob whitelist |
+| 580+ | `normalizeTelemetrySchema()` |
+| 632+ | `buildSubmitPayload()` |
+| 757+ | `TelemetryManager.start()` — cloud vs os/vscode bootstrap |
+| 908+ | `refreshFromServerIfStale()` |
+| 1112+ | `registerStepEvent()` — mutates `current`, `submit()` / `save()` / `streamEvent()` |
+| 1323+ | `submit()` — Breathecode batch then Rigobot batch |
+| 1369+ | `streamEvent()` — optional streaming URL |
+| 1395+ | `submitTelemetryToRigobotViaBeacon()` — unload hook (Rigobot only) |
 
 ---
 
 ## Store (state logic)
 
-### `src/store.tsx`
+### `src/utils/store.tsx`
 
-| Lines | Contents |
-|-------|----------|
-| 424, 480 | Test success/failure handlers → `test` event registration |
-| 520, 538 | Compilation success/failure handlers → `compile` event registration |
-| 547 | Compilation event start |
-| 1061 | `registerTelemetryEvent("open_step", ...)` |
-| 2611 | Submit on tab hidden (`visibilitychange`) |
-| 2621 | Beacon on page close (`pagehide`/`beforeunload`) |
-| 2624 | `visibilitychange` listener |
-| 2625-2626 | `beforeunload` / `pagehide` listeners |
-| 2647 | Alternative `open_step` registration |
+| Lines (approx.) | Contents |
+|-----------------|----------|
+| 454, 493 | Test handlers → `registerTelemetryEvent("test", ...)` |
+| 530, 547 | Compile handlers → `registerTelemetryEvent("compile", ...)` |
+| 1069, 2656 | `registerTelemetryEvent("open_step", ...)` |
+| 2539+ | `startTelemetry` — assigns `TelemetryManager.urls`, calls `TelemetryManager.start()` |
+| 2620 | Tab hidden → `TelemetryManager.submit()` (Breathecode + Rigobot) |
+| 2630 | `pagehide` / `beforeunload` → `submitTelemetryToRigobotViaBeacon()` (Rigobot only) |
+| 2633 | `visibilitychange` listener registration |
 
 ---
 
 ## Components that register events
 
-### `src/components/composites/Agent.tsx`
-- Line **618**: Registers `ai_interaction` when AI response completes
+### `src/components/Rigobot/Agent.tsx`
+- Registers `ai_interaction` when AI response completes
 
-### `src/components/composites/NewAgent.tsx`
-- Line **544**: Registers `ai_interaction` (new agent variant)
+### `src/components/Rigobot/NewAgent.tsx`
+- Registers `ai_interaction` (new agent variant)
 
 ### `src/components/composites/QuizRenderer.tsx`
-- Line **76-84**: `registerTesteableElement` on mount (debounced 2s), passes `language`
-- Line **249-258**: `registerTesteableElement` on quiz submission, passes `language`
-- Line **228**: Registers `quiz_submission`
+- `registerTesteableElement` on mount / submission (with `language`)
+- Registers `quiz_submission`
 
 ### `src/components/composites/Markdowner.tsx` (`FillInTheBlankRenderer`)
-- Line **1082-1088**: `registerTesteableElement` on mount (debounced 2s), passes `language`
-- Line **1239**: Registers `quiz_submission` (inline quizzes in markdown)
+- `registerTesteableElement` (with `language`)
+- Registers `quiz_submission` for inline quizzes
 
 ### `src/components/composites/OpenQuestion.tsx`
-- Line **101-103**: `registerTesteableElement` on mount (debounced 2s), passes `language`
-- Line **237-246**: `registerTesteableElement` on successful evaluation, passes `language`
-- Line **250**: Registers `quiz_submission` (open-ended questions)
+- `registerTesteableElement` (with `language`)
+- Registers `quiz_submission`
 
 ### `src/components/composites/LessonRenderer/LessonRenderer.tsx`
 - Emits `lesson_rendered` eventBus event in a `useEffect` whenever `currentContent` or
   `currentExercisePosition` changes. This signals `TelemetryManager.onLessonRendered`
-  to start the 7s debounce for read-only step detection.
+  to start the debounce for read-only step detection.
 
 ### `src/managers/eventBus.ts`
 - Typed event bus (mitt). Relevant telemetry events:
@@ -90,12 +79,12 @@ The heart of all telemetry logic in the IDE.
 ## Privacy and sanitization
 
 ### `src/utils/piiSanitizer.ts`
-- Lines **78-91**: Masks `fullname → "[REDACTED]"` in telemetry
-- Lines **101-120**: Hook on `LocalStorage.set()`
+- Masks `fullname → "[REDACTED]"` in telemetry
+- Hook on `LocalStorage.set()`
 - Removes: `email`, `user.email`, `user.first_name`, `user.last_name`, `user.github`
 
 ### `src/managers/localStorage.ts`
-- Lines **16-23**: `LocalStorage.set()` — sanitizer interception point
+- `LocalStorage.set()` — sanitizer interception point
 - Telemetry key: `"TELEMETRY"`
 
 ---

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -14,6 +14,7 @@ import { TAgent } from "../utils/storeTypes";
 import { LEARNPACK_LOCAL_URL } from "../utils/creator";
 import { debounce, RIGOBOT_HOST } from "../utils/lib";
 import { eventBus } from "./eventBus";
+import { fetchLearnpackPackageAssetIds } from "../utils/apiCalls";
 
 export interface IFile {
   path: string;
@@ -21,10 +22,19 @@ export interface IFile {
   hidden: boolean;
 }
 
+function withAssetIdQuery(batchUrl: string, assetIds: number[]): string {
+  if (assetIds.length === 0) {
+    return batchUrl;
+  }
+  const sep = batchUrl.includes("?") ? "&" : "?";
+  return `${batchUrl}${sep}asset_id=${assetIds.join(",")}`;
+}
+
 const sendBatchTelemetryBreathecode = async function (
   url: string,
   body: object,
-  token: string
+  token: string,
+  packageAssetIds?: number[]
 ): Promise<AxiosResponse<any> | void> {
   if (!url || !token) {
     console.error("URL and token are required");
@@ -38,8 +48,10 @@ const sendBatchTelemetryBreathecode = async function (
     Authorization: `Token ${token}`,
   };
 
+  const postUrl = withAssetIdQuery(url, packageAssetIds ?? []);
+
   try {
-    const response: AxiosResponse<any> = await axios.post(url, body, {
+    const response: AxiosResponse<any> = await axios.post(postUrl, body, {
       headers,
     });
 
@@ -728,12 +740,15 @@ interface ITelemetryManager {
   save: () => void;
   retrieve: () => Promise<ITelemetryJSONSchema | null>;
   getStep: (stepPosition: number) => TStep | null;
+  /** Breathecode registry asset IDs from Rigobot package; not persisted in telemetry blob. */
+  packageAssetIds: number[];
 }
 
 const TelemetryManager: ITelemetryManager = {
   current: null,
   urls: {},
   telemetryKey: "",
+  packageAssetIds: [],
   listeners: {},
   agent: "cloud",
   prevStep: undefined,
@@ -756,6 +771,7 @@ const TelemetryManager: ITelemetryManager = {
 
   start: function (agent, steps, tutorialSlug, storageKey, student) {
     this.activeHashes = new Map<string, Set<string>>();
+    this.packageAssetIds = [];
     this.telemetryKey = storageKey;
     this.tutorialSlug = tutorialSlug;
     this.agent = agent;
@@ -772,19 +788,29 @@ const TelemetryManager: ITelemetryManager = {
     if (agent === "cloud") {
       this.reconciling = true;
       return (async () => {
+        let submitLocalIfNewer = false;
         try {
           const localRaw = LocalStorage.get(this.telemetryKey);
           const localTelemetry =
             localRaw && localRaw.slug === tutorialSlug ? localRaw : null;
 
-          let serverTelemetry: ITelemetryJSONSchema | null = null;
-          if (student.rigo_token && student.user_id) {
-            serverTelemetry = await fetchTelemetryFromServer({
-              userId: student.user_id,
-              packageSlug: tutorialSlug,
-              rigoToken: student.rigo_token,
-            });
-          }
+          const [serverTelemetry, packageAssetIds] = await Promise.all([
+            student.rigo_token && student.user_id
+              ? fetchTelemetryFromServer({
+                  userId: student.user_id,
+                  packageSlug: tutorialSlug,
+                  rigoToken: student.rigo_token,
+                })
+              : Promise.resolve(null as ITelemetryJSONSchema | null),
+            student.rigo_token?.trim() && tutorialSlug
+              ? fetchLearnpackPackageAssetIds(
+                  student.rigo_token,
+                  tutorialSlug
+                )
+              : Promise.resolve([] as number[]),
+          ]);
+
+          this.packageAssetIds = packageAssetIds;
 
           const { telemetry, source } = reconcileTelemetry(
             serverTelemetry,
@@ -816,9 +842,7 @@ const TelemetryManager: ITelemetryManager = {
             return;
           }
 
-          if (source === "local") {
-            await this.submit();
-          }
+          submitLocalIfNewer = source === "local";
         } catch (error) {
           console.log("ERROR: There was a problem starting the Telemetry");
           console.error(error);
@@ -828,11 +852,15 @@ const TelemetryManager: ITelemetryManager = {
         } finally {
           this.reconciling = false;
         }
+
+        if (submitLocalIfNewer && student.user_id) {
+          await this.submit();
+        }
       })();
     }
 
     return this.retrieve()
-      .then((prevTelemetry) => {
+      .then(async (prevTelemetry) => {
         if (prevTelemetry) {
           this.current = normalizeTelemetrySchema(
             prevTelemetry,
@@ -893,7 +921,14 @@ const TelemetryManager: ITelemetryManager = {
           return;
         }
 
-        this.submit();
+        if (this.user.rigo_token?.trim() && tutorialSlug) {
+          this.packageAssetIds = await fetchLearnpackPackageAssetIds(
+            this.user.rigo_token,
+            tutorialSlug
+          );
+        }
+
+        await this.submit();
       })
       .catch((error) => {
         console.log("ERROR: There was a problem starting the Telemetry");
@@ -1343,7 +1378,12 @@ const TelemetryManager: ITelemetryManager = {
     const body = buildSubmitPayload(this.current, this.user.id);
 
     try {
-      await sendBatchTelemetryBreathecode(url, body, this.user.token);
+      await sendBatchTelemetryBreathecode(
+        url,
+        body,
+        this.user.token,
+        this.packageAssetIds
+      );
       await sendBatchTelemetryRigobot(body, this.user.rigo_token);
     } catch (error) {
       console.error("Error submitting telemetry", error);

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -126,6 +126,49 @@ export async function useConsumableCall(
   }
 }
 
+function normalizeLearnpackPackageAssetIds(raw: unknown): number[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const out: number[] = [];
+  for (const item of raw) {
+    const n = typeof item === "number" ? item : Number(item);
+    if (Number.isFinite(n)) {
+      out.push(n);
+    }
+  }
+  return out;
+}
+
+/**
+ * Breathecode asset IDs for telemetry batch query param; sourced from Rigobot package record.
+ */
+export async function fetchLearnpackPackageAssetIds(
+  rigoToken: string,
+  packageSlug: string
+): Promise<number[]> {
+  if (!rigoToken?.trim() || !packageSlug) {
+    return [];
+  }
+
+  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${encodeURIComponent(packageSlug)}/`;
+
+  try {
+    const response = await axios.get<{ asset_ids?: unknown }>(url, {
+      headers: {
+        Authorization: `Token ${rigoToken.trim()}`,
+      },
+    });
+    return normalizeLearnpackPackageAssetIds(response.data?.asset_ids);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return [];
+    }
+    console.warn("fetchLearnpackPackageAssetIds failed:", error);
+    return [];
+  }
+}
+
 export const isPackageAuthor = async (
   token: string,
   packageSlug: string


### PR DESCRIPTION
Load package asset ids from Rigobot once at `TelemetryManager.start` and pass them only on POST to the Breathecode batch URL as query string.
Example: `https://breathecode.herokuapp.com/v1/assignment/me/telemetry?asset_id=3351,3065`