### PR TITLE
Rellenar package_id en telemetría vía Rigobot cuando telemetría del servidor no lo aporta

### DIFF
--- a/.agents/skills/telemetry/SKILL.md
+++ b/.agents/skills/telemetry/SKILL.md
@@ -10,7 +10,9 @@ description: >
   TelemetryManager, registerTelemetryEvent, registerTesteableElement,
   hasPendingTasks, is_completed, testeable_elements, quiz_submission, open_step,
   reconcileTelemetry, normalizeTelemetrySchema, workout_session, lesson_rendered,
-  completeStepIfReadOnly, onLessonRendered, activeHashes, or anything related to
+  completeStepIfReadOnly, onLessonRendered, activeHashes, package_id,
+  mergePackageIdIfMissing, fetchPackageMetadata, getPackageBySlug,
+  PackageMetadataListener, global_metrics, global_indicators, or anything related to
   completion_rate, step tracking, or telemetry submission/persistence.
 ---
 
@@ -109,13 +111,21 @@ For compilation/test events, data must be base64-encoded (see `stringToBase64` /
 3. `reconcileTelemetry()` (see Reconciliation section)
 4. Apply session fields (`user_id`, `fullname`, `cohort_id`, `academy_id`), `save()`, then if reconciliation source is `"local"`, **`submit()`** immediately
 
-There is **no separate “resolve package_id” HTTP step** in this bootstrap path; `package_id` may appear inside stored or server blobs and is preserved when whitelisted.
+**`package_id` — optional Rigobot lookup and merge (not part of `start()` itself):**
+- The persisted blob may already contain `package_id` (localStorage, server GET, or prior sessions). It is **whitelisted** (`TELEMETRY_WHITELIST_KEYS`).
+- When missing or empty, the IDE resolves the LearnPack package record **via HTTP**: `getPackageBySlug()` → `GET ${RIGOBOT_HOST}/v1/learnpack/package/<slug>/` (same path used for `asset_ids`; see `references/apis.md`). The response `id` is stored in Zustand as **`packageId` + `packageIdSlug`** (`src/utils/store.tsx` / `storeTypes.ts`).
+- **`PackageMetadataListener`** (`src/components/PackageMetadataListener.tsx`, mounted in `App.tsx`) runs when **Rigobot token + config slug** are set; it calls **`fetchPackageMetadata()`**, which skips the network if the slug still matches the cached `packageIdSlug` with a non-null `packageId`, otherwise fetches and calls **`TelemetryManager.mergePackageIdIfMissing(idStr)`**.
+- **`startTelemetry()`** after `await TelemetryManager.start(...)` calls **`mergePackageIdIfMissing(pkgId)`** again if the store already has `packageId` — this covers ordering where metadata resolved before telemetry finished bootstrapping.
+- **`mergePackageIdIfMissing`** only writes when `current.package_id` is missing/empty; it always stores a **string** (`String(packageId)`). The schema allows `number | string`; the IDE normalizes new fills to **string**.
+- **Course change:** inside **`fetchExercises`**, if the incoming config slug **differs** from the previous non-empty slug, the store clears **`packageId` / `packageIdSlug`** so the next listener/metadata pass targets the new package.
 
 **`submit()` — dual batch POST (same body, strict order):**
 1. `POST` **`config.telemetry.batch`** with **Breathecode** token (`Authorization: Token <breathecode_token>`).
 2. If that succeeds, `POST` **`${RIGOBOT_HOST}/v1/learnpack/telemetry`** with **Rigobot** token.
 
 If the Breathecode POST **throws**, the Rigobot POST is **not** attempted (single `try` / sequential `await`).
+
+When **both** POSTs succeed, `submit()` copies **`global_metrics`** and **`global_indicators`** from the same payload object produced by **`buildSubmitPayload`** into **`TelemetryManager.current`**, then **`save()`**, so localStorage/CLI reflect the latest computed aggregates after a successful dual submit.
 
 **When `submit()` runs** (non-exhaustive):
 - After **`test`** when `exit_code === 0` (and related completion logic)

--- a/.agents/skills/telemetry/references/apis.md
+++ b/.agents/skills/telemetry/references/apis.md
@@ -62,11 +62,12 @@ Body: ITelemetryJSONSchema (full blob with computed metrics)
 
 ### GET /v1/learnpack/package/${slug}/
 
-**Purpose:** Package metadata on Rigobot (e.g. `asset_ids`, existence check for authors).
+**Purpose:** Package metadata on Rigobot — `asset_ids`, **`id`** (LearnPack package id), author checks, etc.
 
 **Used in:**
 
 - `src/utils/apiCalls.ts` — `isPackageAuthor` (status 200 vs 404); `fetchLearnpackPackageAssetIds()` parses `asset_ids` for telemetry batch (Breathecode query param only).
+- **`getPackageBySlug()`** — reads **`id`** from the JSON body for Zustand (`packageId` / `packageIdSlug`) and for **`TelemetryManager.mergePackageIdIfMissing`**. Does **not** throw on failure; returns `null` on errors or missing `id`.
 
 ```
 GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
@@ -76,6 +77,8 @@ Headers:
 ```
 
 During `TelemetryManager.start()` (cloud and local agents), the IDE loads `asset_ids` **once** via `fetchLearnpackPackageAssetIds` when `rigo_token` and package slug are present. IDs are kept in memory (`TelemetryManager.packageAssetIds`), not in the persisted telemetry blob.
+
+**Package id for the telemetry blob** is filled separately: **`PackageMetadataListener`** → **`fetchPackageMetadata()`** → **`getPackageBySlug()`** → **`mergePackageIdIfMissing`**. Same URL as above; independent of the `asset_ids` fetch used for Breathecode `asset_id` query params.
 
 ---
 

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -19,6 +19,8 @@ The heart of all telemetry logic in the IDE.
 | (next) | `TELEMETRY_WHITELIST_KEYS` — persisted blob whitelist |
 | (next) | `normalizeTelemetrySchema()` |
 | (next) | `buildSubmitPayload()` |
+| ~1359–1399 | `submit()` — dual batch POST; on success copies `global_metrics` / `global_indicators` from payload to `current` + `save()` |
+| ~1421–1434 | `mergePackageIdIfMissing()` — fills `package_id` string when absent |
 | 772+ | `TelemetryManager.start()` — cloud vs os/vscode bootstrap; loads `packageAssetIds` |
 | (next) | `refreshFromServerIfStale()` |
 | (next) | `registerStepEvent()` — mutates `current`, `submit()` / `save()` / `streamEvent()` |
@@ -37,10 +39,19 @@ The heart of all telemetry logic in the IDE.
 | 454, 493 | Test handlers → `registerTelemetryEvent("test", ...)` |
 | 530, 547 | Compile handlers → `registerTelemetryEvent("compile", ...)` |
 | 1069, 2656 | `registerTelemetryEvent("open_step", ...)` |
-| 2539+ | `startTelemetry` — assigns `TelemetryManager.urls`, calls `TelemetryManager.start()` |
+| ~872–876 | `fetchExercises` — if config **slug** changes from a previous non-empty value, clears `packageId` / `packageIdSlug` |
+| ~895–911 | `fetchPackageMetadata` — `getPackageBySlug`, cache by slug, `mergePackageIdIfMissing` |
+| 2539+ | `startTelemetry` — assigns `TelemetryManager.urls`, calls `TelemetryManager.start()`, then `mergePackageIdIfMissing` if store `packageId` set |
 | 2620 | Tab hidden → `TelemetryManager.submit()` (Breathecode + Rigobot) |
 | 2630 | `pagehide` / `beforeunload` → `submitTelemetryToRigobotViaBeacon()` (Rigobot only) |
 | 2633 | `visibilitychange` listener registration |
+
+---
+
+## Package id wiring
+
+### `src/components/PackageMetadataListener.tsx`
+- `useEffect` on **Rigobot token** + **config slug**; calls `fetchPackageMetadata()` when both are non-empty (no UI).
 
 ---
 
@@ -95,6 +106,10 @@ The heart of all telemetry logic in the IDE.
 ### `src/utils/apiCalls.ts`
 
 - `fetchLearnpackPackageAssetIds()` — GET Rigobot package, returns `asset_ids` as `number[]` for Breathecode batch URL (telemetry bootstrap).
+- `getPackageBySlug()` — GET same package URL; returns `{ id }` or `null` (no throw); used for `package_id` merge path.
+
+### `src/App.tsx`
+- Renders `<PackageMetadataListener />` next to other global listeners.
 
 ---
 

--- a/.agents/skills/telemetry/references/schema.md
+++ b/.agents/skills/telemetry/references/schema.md
@@ -10,7 +10,7 @@ interface ITelemetryJSONSchema {
   user_id: string
   fullname: string               // "[REDACTED]" in localStorage
   slug: string                   // package/course slug
-  package_id?: number | string   // Rigobot ID
+  package_id?: number | string   // Rigobot LearnPack package id (merge fills via String())
   version: string                // e.g. "CLOUD:0.46.0"
   cohort_id: string | null
   academy_id: string | null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import PreviewGenerator from "./components/composites/PreviewImageGenerator/Prev
 import { PositionHandler } from "./components/composites/PositionHandler/PositionHandler";
 import TranslationListener from "./components/Creator/TranslationListener";
 import SyncNotificationListener from "./components/SyncNotifications/SyncNotificationListener";
+import PackageMetadataListener from "./components/PackageMetadataListener";
 import EventListener from "./managers/eventListener";
 export default function Home() {
   const start = useStore((s) => s.start);
@@ -52,6 +53,7 @@ export default function Home() {
       className={`${theme} ${isIframe ? "iframe-mode" : ""}`}
     >
       <ModalsContainer />
+      <PackageMetadataListener />
       <PublishNavbar />
       <PositionHandler />
       {environment === "creatorWeb" && <PreviewGenerator />}

--- a/src/components/PackageMetadataListener.tsx
+++ b/src/components/PackageMetadataListener.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import useStore from "../utils/store";
+
+/**
+ * When Rigobot token and package slug are available, fetches package id from Rigobot
+ * and merges package_id into local telemetry if missing (see store.fetchPackageMetadata).
+ */
+export default function PackageMetadataListener() {
+  const token = useStore((s) => s.token);
+  const slug = useStore((s) => s.configObject?.config?.slug ?? "");
+
+  useEffect(() => {
+    if (!token?.trim() || !slug.trim()) {
+      return;
+    }
+    void useStore.getState().fetchPackageMetadata();
+  }, [token, slug]);
+
+  return null;
+}

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -740,6 +740,7 @@ interface ITelemetryManager {
   save: () => void;
   retrieve: () => Promise<ITelemetryJSONSchema | null>;
   getStep: (stepPosition: number) => TStep | null;
+  mergePackageIdIfMissing: (packageId: number | string) => void;
   /** Breathecode registry asset IDs from Rigobot package; not persisted in telemetry blob. */
   packageAssetIds: number[];
 }
@@ -1385,6 +1386,17 @@ const TelemetryManager: ITelemetryManager = {
         this.packageAssetIds
       );
       await sendBatchTelemetryRigobot(body, this.user.rigo_token);
+      const payload = body as {
+        global_metrics?: ITelemetryJSONSchema["global_metrics"];
+        global_indicators?: ITelemetryJSONSchema["global_indicators"];
+      };
+      if (payload.global_metrics !== undefined) {
+        this.current.global_metrics = payload.global_metrics;
+      }
+      if (payload.global_indicators !== undefined) {
+        this.current.global_indicators = payload.global_indicators;
+      }
+      this.save();
     } catch (error) {
       console.error("Error submitting telemetry", error);
     }
@@ -1404,6 +1416,21 @@ const TelemetryManager: ITelemetryManager = {
 
   getStep: function (stepPosition: number) {
     return this.current?.steps[stepPosition] || null;
+  },
+
+  mergePackageIdIfMissing: function (packageId: number | string) {
+    if (!this.current) {
+      return;
+    }
+    if (
+      this.current.package_id !== undefined &&
+      this.current.package_id !== null &&
+      this.current.package_id !== ""
+    ) {
+      return;
+    }
+    this.current.package_id = packageId;
+    this.save();
   },
 
   streamEvent: async function (stepPosition, event, data) {

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1429,7 +1429,7 @@ const TelemetryManager: ITelemetryManager = {
     ) {
       return;
     }
-    this.current.package_id = packageId;
+    this.current.package_id = String(packageId);
     this.save();
   },
 

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -169,6 +169,45 @@ export async function fetchLearnpackPackageAssetIds(
   }
 }
 
+/**
+ * Rigobot package record for a slug; `id` is the Learnpack package id.
+ * Returns null on network errors or non-success (does not throw).
+ */
+export async function getPackageBySlug(
+  rigoToken: string,
+  packageSlug: string
+): Promise<{ id: number | string } | null> {
+  if (!rigoToken?.trim() || !packageSlug) {
+    return null;
+  }
+
+  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${encodeURIComponent(packageSlug)}/`;
+
+  try {
+    const response = await axios.get<{ id?: unknown }>(url, {
+      headers: {
+        Authorization: `Token ${rigoToken.trim()}`,
+      },
+    });
+
+    const raw = response.data?.id;
+    if (raw === undefined || raw === null) {
+      return null;
+    }
+    const id =
+      typeof raw === "number" || typeof raw === "string"
+        ? raw
+        : Number(raw);
+    if (typeof id === "number" && !Number.isFinite(id)) {
+      return null;
+    }
+    return { id };
+  } catch (error) {
+    console.warn("getPackageBySlug failed:", error);
+    return null;
+  }
+}
+
 export const isPackageAuthor = async (
   token: string,
   packageSlug: string

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -55,6 +55,7 @@ import {
   getSession,
   updateSession,
   isPackageAuthor,
+  getPackageBySlug,
 } from "./apiCalls";
 import TelemetryManager, {
   TStep,
@@ -262,6 +263,8 @@ const useStore = create<IStore>((set, get) => ({
   showFeedback: false,
   token: "",
   bc_token: "",
+  packageId: null as number | string | null,
+  packageIdSlug: null as string | null,
   buildbuttonText: {
     text: "see-terminal-output",
     className: "",
@@ -866,6 +869,12 @@ The user's set up the application in "${language}" language, give your feedback 
 
       if (config.config.title.us) set({ lessonTitle: config.config.title.us });
 
+      const prevSlug = (get().configObject?.config?.slug ?? "").trim();
+      const newSlug = (config.config.slug ?? "").trim();
+      if (prevSlug !== "" && prevSlug !== newSlug) {
+        set({ packageId: null, packageIdSlug: null });
+      }
+
       set({ configObject: config });
 
       if (
@@ -882,6 +891,22 @@ The user's set up the application in "${language}" language, give your feedback 
       disconnected();
       return false;
     }
+  },
+  fetchPackageMetadata: async () => {
+    const { token, configObject, packageId, packageIdSlug } = get();
+    const slug = (configObject?.config?.slug ?? "").trim();
+    if (!token?.trim() || !slug) {
+      return;
+    }
+    if (slug === packageIdSlug && packageId != null) {
+      return;
+    }
+    const result = await getPackageBySlug(token, slug);
+    if (!result) {
+      return;
+    }
+    set({ packageId: result.id, packageIdSlug: slug });
+    TelemetryManager.mergePackageIdIfMissing(result.id);
   },
   checkParams: ({ justReturn }) => {
     const { setLanguage, setPosition, language, setOpenedModals } = get();
@@ -2608,6 +2633,10 @@ The user's set up the application in "${language}" language, give your feedback 
           cohort_id: params.cohort_id || "",
           academy_id: params.academy_id || "",
         });
+        const pkgId = get().packageId;
+        if (pkgId != null) {
+          TelemetryManager.mergePackageIdIfMissing(pkgId);
+        }
       } finally {
         set({ telemetryReady: true });
       }

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -263,7 +263,7 @@ const useStore = create<IStore>((set, get) => ({
   showFeedback: false,
   token: "",
   bc_token: "",
-  packageId: null as number | string | null,
+  packageId: null as string | null,
   packageIdSlug: null as string | null,
   buildbuttonText: {
     text: "see-terminal-output",
@@ -905,8 +905,9 @@ The user's set up the application in "${language}" language, give your feedback 
     if (!result) {
       return;
     }
-    set({ packageId: result.id, packageIdSlug: slug });
-    TelemetryManager.mergePackageIdIfMissing(result.id);
+    const idStr = String(result.id);
+    set({ packageId: idStr, packageIdSlug: slug });
+    TelemetryManager.mergePackageIdIfMissing(idStr);
   },
   checkParams: ({ justReturn }) => {
     const { setLanguage, setPosition, language, setOpenedModals } = get();

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -283,8 +283,8 @@ export interface IStore {
   user: TUser;
   token: string;
   bc_token: string;
-  /** Rigobot Learnpack package id for the current course slug; null until resolved. */
-  packageId: number | string | null;
+  /** Rigobot Learnpack package id for the current course slug; null until resolved. Always string when set. */
+  packageId: string | null;
   /** Slug for which `packageId` is valid; used to skip refetch and to invalidate on course change. */
   packageIdSlug: string | null;
   assessmentConfig: TAssessmentConfig;

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -283,6 +283,10 @@ export interface IStore {
   user: TUser;
   token: string;
   bc_token: string;
+  /** Rigobot Learnpack package id for the current course slug; null until resolved. */
+  packageId: number | string | null;
+  /** Slug for which `packageId` is valid; used to skip refetch and to invalidate on course change. */
+  packageIdSlug: string | null;
   assessmentConfig: TAssessmentConfig;
   configObject: IConfigObject;
   videoTutorial: string;
@@ -374,6 +378,8 @@ export interface IStore {
   fetchSingleExerciseInfo: (index: number) => Promise<TExercise>;
   toggleFeedback: () => void;
   fetchExercises: () => void;
+  /** GET package metadata from Rigobot when token and config slug exist; merges package_id into telemetry if missing. */
+  fetchPackageMetadata: () => Promise<void>;
   updateEditorTabs: () => void;
   setFileLoadNotFound: (lessonSlug: string, filename: string, notFound: boolean) => void;
   clearFileLoadNotFoundForLesson: (lessonSlug: string) => void;


### PR DESCRIPTION
## Problema

Si el blob de telemetría que llegaba del servidor **no traía `package_id`**, el estado local y los **POST** de telemetría podían quedar **sin `package_id`**. 
Pasaba en dos situaciones: 
1. primera carga del paquete para un usuario (aún no hay telemetría en servidor) y 
2. cuando el origen de los datos del servidor era **BigQuery** (sin `package_id`); cuando venía del **buffer en Redis**, el registro **sí** incluía `package_id`.

## Solución

- Se obtiene el identificador del paquete con **`GET /v1/learnpack/package/<slug>/`** (Rigobot), se guarda en el store y se **fusiona** en el blob de telemetría cuando falta. 
- Un **listener** en la raíz dispara el fetch cuando hay token y slug.
- Al cambiar de curso se **invalida** el id anterior. 

**Además**:
- Tras cada **submit** de telemetría exitoso se persisten también **`global_metrics`** / **`global_indicators`** en el blob local.
- Actualizar skill telemetry