### PR TITLE
refactor(publish): improve publish error UX for Breathecode asset sync

### DIFF
--- a/.agents/skills/telemetry/SKILL.md
+++ b/.agents/skills/telemetry/SKILL.md
@@ -12,7 +12,7 @@ description: >
   reconcileTelemetry, normalizeTelemetrySchema, workout_session, lesson_rendered,
   completeStepIfReadOnly, onLessonRendered, activeHashes, package_id,
   mergePackageIdIfMissing, fetchPackageMetadata, getPackageBySlug,
-  PackageMetadataListener, global_metrics, global_indicators, or anything related to
+  PackageMetadataListener, ensureTelemetryStarted, global_metrics, global_indicators, or anything related to
   completion_rate, step tracking, or telemetry submission/persistence.
 ---
 
@@ -391,6 +391,22 @@ Each `TelemetryManager.start()` call closes the previous session (sets `ended_at
 last_interaction_at` if no `ended_at`) and opens a new one. Handled by
 `normalizeWorkoutSession()` inside `normalizeTelemetrySchema`.
 
+## Post-login / late session (second chance after bootstrap)
+
+`App` calls `start()` once. That chain runs `startTelemetry()` after `fetchExercises` / `checkParams`. If the user is **not** logged in yet, `startTelemetry` returns early (no `user` / `bc_token`) and telemetry never starts until something calls **`ensureTelemetryStarted()`**, which delegates to **`startTelemetry()`**.
+
+**Call sites that wire late session:**
+
+| Flow | `src/utils/store.tsx` |
+|------|------------------------|
+| Successful **`loginToRigo`** | `await getOrCreateActiveSession()` then `await ensureTelemetryStarted()` |
+| **`refreshDataFromAnotherTab`** (e.g. socket `session-refreshed`) | `await getOrCreateActiveSession()`, `initRigoAI()`, `await ensureTelemetryStarted()` |
+| **`checkRigobotInvitation`** (Rigobot token after invite) | If Rigobot `token` and `configObject` exist: `await getOrCreateActiveSession()` then `await ensureTelemetryStarted()` |
+
+**`skipDuplicateBootstrap`:** before `await TelemetryManager.start`, the store sets `skipDuplicateBootstrap = TelemetryManager.started && TelemetryManager.current != null`. `TelemetryManager.start` always runs (it refreshes `this.user` / tokens). When `skipDuplicateBootstrap` is true, the store **does not** register the struggle listeners again or emit the **initial** `open_step` from `startTelemetry` (avoids duplicates after a successful first bootstrap). Document lifecycle listeners (`visibilitychange`, unload beacon) remain guarded by `telemetryLifecycleListenersRegistered`.
+
+**`telemetryReady`:** set to **`true` only when `TelemetryManager.start` completes without throwing**; on failure it is set to **`false`**.
+
 ## Important gotchas
 
 - **`open_step` is guarded by `telemetryReady`** — `setPosition` only fires
@@ -398,11 +414,7 @@ last_interaction_at` if no `ended_at`) and opens a new one. Handled by
   enqueued before `TelemetryManager.start()` completes, which could trigger completion
   logic with stale state. `startTelemetry()` registers the initial `open_step` itself.
 
-- **Race condition: `startTelemetry` + `getOrCreateActiveSession`** — both are called
-  concurrently on startup. If `getOrCreateActiveSession` resolves after telemetry is
-  ready and calls `setPosition(N)` for the same step that's already open, `open_step(N)`
-  fires with `prevStep === N === stepPosition`. The guard `this.prevStep !== stepPosition`
-  prevents this from triggering auto-completion.
+- **Race condition: `startTelemetry` + `getOrCreateActiveSession`** — on **startup** they are still invoked back-to-back without awaiting `getOrCreateActiveSession` in the initial chain. After **login**, the store **`await`s `getOrCreateActiveSession()` before `ensureTelemetryStarted()`** to align session before the first real `open_step`. If `getOrCreateActiveSession` resolves after telemetry is ready and calls `setPosition(N)` for the same step that's already open, `open_step(N)` fires with `prevStep === N === stepPosition`. The guard `this.prevStep !== stepPosition` prevents this from triggering auto-completion.
 
 - **`open_step` never completes steps with empty `testeable_elements`** — read-only step
   completion relies on `onLessonRendered` (7s debounce). Never add completion logic to

--- a/.agents/skills/telemetry/SKILL.md
+++ b/.agents/skills/telemetry/SKILL.md
@@ -10,7 +10,9 @@ description: >
   TelemetryManager, registerTelemetryEvent, registerTesteableElement,
   hasPendingTasks, is_completed, testeable_elements, quiz_submission, open_step,
   reconcileTelemetry, normalizeTelemetrySchema, workout_session, lesson_rendered,
-  completeStepIfReadOnly, onLessonRendered, activeHashes, or anything related to
+  completeStepIfReadOnly, onLessonRendered, activeHashes, package_id,
+  mergePackageIdIfMissing, fetchPackageMetadata, getPackageBySlug,
+  PackageMetadataListener, global_metrics, global_indicators, or anything related to
   completion_rate, step tracking, or telemetry submission/persistence.
 ---
 
@@ -109,13 +111,21 @@ For compilation/test events, data must be base64-encoded (see `stringToBase64` /
 3. `reconcileTelemetry()` (see Reconciliation section)
 4. Apply session fields (`user_id`, `fullname`, `cohort_id`, `academy_id`), `save()`, then if reconciliation source is `"local"`, **`submit()`** immediately
 
-There is **no separate “resolve package_id” HTTP step** in this bootstrap path; `package_id` may appear inside stored or server blobs and is preserved when whitelisted.
+**`package_id` — optional Rigobot lookup and merge (not part of `start()` itself):**
+- The persisted blob may already contain `package_id` (localStorage, server GET, or prior sessions). It is **whitelisted** (`TELEMETRY_WHITELIST_KEYS`).
+- When missing or empty, the IDE resolves the LearnPack package record **via HTTP**: `getPackageBySlug()` → `GET ${RIGOBOT_HOST}/v1/learnpack/package/<slug>/` (same path used for `asset_ids`; see `references/apis.md`). The response `id` is stored in Zustand as **`packageId` + `packageIdSlug`** (`src/utils/store.tsx` / `storeTypes.ts`).
+- **`PackageMetadataListener`** (`src/components/PackageMetadataListener.tsx`, mounted in `App.tsx`) runs when **Rigobot token + config slug** are set; it calls **`fetchPackageMetadata()`**, which skips the network if the slug still matches the cached `packageIdSlug` with a non-null `packageId`, otherwise fetches and calls **`TelemetryManager.mergePackageIdIfMissing(idStr)`**.
+- **`startTelemetry()`** after `await TelemetryManager.start(...)` calls **`mergePackageIdIfMissing(pkgId)`** again if the store already has `packageId` — this covers ordering where metadata resolved before telemetry finished bootstrapping.
+- **`mergePackageIdIfMissing`** only writes when `current.package_id` is missing/empty; it always stores a **string** (`String(packageId)`). The schema allows `number | string`; the IDE normalizes new fills to **string**.
+- **Course change:** inside **`fetchExercises`**, if the incoming config slug **differs** from the previous non-empty slug, the store clears **`packageId` / `packageIdSlug`** so the next listener/metadata pass targets the new package.
 
 **`submit()` — dual batch POST (same body, strict order):**
 1. `POST` **`config.telemetry.batch`** with **Breathecode** token (`Authorization: Token <breathecode_token>`).
 2. If that succeeds, `POST` **`${RIGOBOT_HOST}/v1/learnpack/telemetry`** with **Rigobot** token.
 
 If the Breathecode POST **throws**, the Rigobot POST is **not** attempted (single `try` / sequential `await`).
+
+When **both** POSTs succeed, `submit()` copies **`global_metrics`** and **`global_indicators`** from the same payload object produced by **`buildSubmitPayload`** into **`TelemetryManager.current`**, then **`save()`**, so localStorage/CLI reflect the latest computed aggregates after a successful dual submit.
 
 **When `submit()` runs** (non-exhaustive):
 - After **`test`** when `exit_code === 0` (and related completion logic)

--- a/.agents/skills/telemetry/references/apis.md
+++ b/.agents/skills/telemetry/references/apis.md
@@ -62,11 +62,12 @@ Body: ITelemetryJSONSchema (full blob with computed metrics)
 
 ### GET /v1/learnpack/package/${slug}/
 
-**Purpose:** Package metadata on Rigobot (e.g. `asset_ids`, existence check for authors).
+**Purpose:** Package metadata on Rigobot — `asset_ids`, **`id`** (LearnPack package id), author checks, etc.
 
 **Used in:**
 
 - `src/utils/apiCalls.ts` — `isPackageAuthor` (status 200 vs 404); `fetchLearnpackPackageAssetIds()` parses `asset_ids` for telemetry batch (Breathecode query param only).
+- **`getPackageBySlug()`** — reads **`id`** from the JSON body for Zustand (`packageId` / `packageIdSlug`) and for **`TelemetryManager.mergePackageIdIfMissing`**. Does **not** throw on failure; returns `null` on errors or missing `id`.
 
 ```
 GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
@@ -76,6 +77,8 @@ Headers:
 ```
 
 During `TelemetryManager.start()` (cloud and local agents), the IDE loads `asset_ids` **once** via `fetchLearnpackPackageAssetIds` when `rigo_token` and package slug are present. IDs are kept in memory (`TelemetryManager.packageAssetIds`), not in the persisted telemetry blob.
+
+**Package id for the telemetry blob** is filled separately: **`PackageMetadataListener`** → **`fetchPackageMetadata()`** → **`getPackageBySlug()`** → **`mergePackageIdIfMissing`**. Same URL as above; independent of the `asset_ids` fetch used for Breathecode `asset_id` query params.
 
 ---
 

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -41,10 +41,10 @@ The heart of all telemetry logic in the IDE.
 | 1069, 2656 | `registerTelemetryEvent("open_step", ...)` |
 | ~872–876 | `fetchExercises` — if config **slug** changes from a previous non-empty value, clears `packageId` / `packageIdSlug` |
 | ~895–911 | `fetchPackageMetadata` — `getPackageBySlug`, cache by slug, `mergePackageIdIfMissing` |
-| 2539+ | `startTelemetry` — assigns `TelemetryManager.urls`, calls `TelemetryManager.start()`, then `mergePackageIdIfMissing` if store `packageId` set |
-| 2620 | Tab hidden → `TelemetryManager.submit()` (Breathecode + Rigobot) |
-| 2630 | `pagehide` / `beforeunload` → `submitTelemetryToRigobotViaBeacon()` (Rigobot only) |
-| 2633 | `visibilitychange` listener registration |
+| `startTelemetry` | Assigns `TelemetryManager.urls`, `skipDuplicateBootstrap` guard, `await TelemetryManager.start()`, `mergePackageIdIfMissing` if store `packageId` set; `telemetryReady` only on success; initial struggle listeners + `open_step` only when not skipping duplicate bootstrap |
+| `ensureTelemetryStarted` | Delegates to `startTelemetry()` — call after **`loginToRigo`**, **`refreshDataFromAnotherTab`**, **`checkRigobotInvitation`** when session arrives after bootstrap |
+| `loginToRigo` / `refreshDataFromAnotherTab` / `checkRigobotInvitation` | Late session: `await getOrCreateActiveSession()` then `await ensureTelemetryStarted()` (plus `initRigoAI` in `refreshDataFromAnotherTab`) |
+| (in `startTelemetry`) | Tab hidden → `TelemetryManager.submit()`; `pagehide` / `beforeunload` → `submitTelemetryToRigobotViaBeacon()`; `visibilitychange` listener — guarded by `telemetryLifecycleListenersRegistered` |
 
 ---
 

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -19,6 +19,8 @@ The heart of all telemetry logic in the IDE.
 | (next) | `TELEMETRY_WHITELIST_KEYS` — persisted blob whitelist |
 | (next) | `normalizeTelemetrySchema()` |
 | (next) | `buildSubmitPayload()` |
+| ~1359–1399 | `submit()` — dual batch POST; on success copies `global_metrics` / `global_indicators` from payload to `current` + `save()` |
+| ~1421–1434 | `mergePackageIdIfMissing()` — fills `package_id` string when absent |
 | 772+ | `TelemetryManager.start()` — cloud vs os/vscode bootstrap; loads `packageAssetIds` |
 | (next) | `refreshFromServerIfStale()` |
 | (next) | `registerStepEvent()` — mutates `current`, `submit()` / `save()` / `streamEvent()` |
@@ -37,10 +39,19 @@ The heart of all telemetry logic in the IDE.
 | 454, 493 | Test handlers → `registerTelemetryEvent("test", ...)` |
 | 530, 547 | Compile handlers → `registerTelemetryEvent("compile", ...)` |
 | 1069, 2656 | `registerTelemetryEvent("open_step", ...)` |
-| 2539+ | `startTelemetry` — assigns `TelemetryManager.urls`, calls `TelemetryManager.start()` |
+| ~872–876 | `fetchExercises` — if config **slug** changes from a previous non-empty value, clears `packageId` / `packageIdSlug` |
+| ~895–911 | `fetchPackageMetadata` — `getPackageBySlug`, cache by slug, `mergePackageIdIfMissing` |
+| 2539+ | `startTelemetry` — assigns `TelemetryManager.urls`, calls `TelemetryManager.start()`, then `mergePackageIdIfMissing` if store `packageId` set |
 | 2620 | Tab hidden → `TelemetryManager.submit()` (Breathecode + Rigobot) |
 | 2630 | `pagehide` / `beforeunload` → `submitTelemetryToRigobotViaBeacon()` (Rigobot only) |
 | 2633 | `visibilitychange` listener registration |
+
+---
+
+## Package id wiring
+
+### `src/components/PackageMetadataListener.tsx`
+- `useEffect` on **Rigobot token** + **config slug**; calls `fetchPackageMetadata()` when both are non-empty (no UI).
 
 ---
 
@@ -95,6 +106,10 @@ The heart of all telemetry logic in the IDE.
 ### `src/utils/apiCalls.ts`
 
 - `fetchLearnpackPackageAssetIds()` — GET Rigobot package, returns `asset_ids` as `number[]` for Breathecode batch URL (telemetry bootstrap).
+- `getPackageBySlug()` — GET same package URL; returns `{ id }` or `null` (no throw); used for `package_id` merge path.
+
+### `src/App.tsx`
+- Renders `<PackageMetadataListener />` next to other global listeners.
 
 ---
 

--- a/.agents/skills/telemetry/references/schema.md
+++ b/.agents/skills/telemetry/references/schema.md
@@ -10,7 +10,7 @@ interface ITelemetryJSONSchema {
   user_id: string
   fullname: string               // "[REDACTED]" in localStorage
   slug: string                   // package/course slug
-  package_id?: number | string   // Rigobot ID
+  package_id?: number | string   // Rigobot LearnPack package id (merge fills via String())
   version: string                // e.g. "CLOUD:0.46.0"
   cohort_id: string | null
   academy_id: string | null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import PreviewGenerator from "./components/composites/PreviewImageGenerator/Prev
 import { PositionHandler } from "./components/composites/PositionHandler/PositionHandler";
 import TranslationListener from "./components/Creator/TranslationListener";
 import SyncNotificationListener from "./components/SyncNotifications/SyncNotificationListener";
+import PackageMetadataListener from "./components/PackageMetadataListener";
 import EventListener from "./managers/eventListener";
 export default function Home() {
   const start = useStore((s) => s.start);
@@ -52,6 +53,7 @@ export default function Home() {
       className={`${theme} ${isIframe ? "iframe-mode" : ""}`}
     >
       <ModalsContainer />
+      <PackageMetadataListener />
       <PublishNavbar />
       <PositionHandler />
       {environment === "creatorWeb" && <PreviewGenerator />}

--- a/src/components/Creator/PublishButton.tsx
+++ b/src/components/Creator/PublishButton.tsx
@@ -20,6 +20,76 @@ type Academy = {
   timezone: string;
 };
 
+/** keep in sync with learnpack-cli/src/utils/api.ts AssetSyncError */
+type AssetSyncError =
+  | { kind: "lang_error"; lang: string; error: { detail: string } }
+  | { kind: "package_error"; error: { detail: string } };
+
+function normalizePublishErrors(raw: unknown): AssetSyncError[] {
+  if (!Array.isArray(raw)) return [];
+  const out: AssetSyncError[] = [];
+  for (const item of raw as Record<string, unknown>[]) {
+    if (item?.kind === "package_error" && item.error && typeof (item.error as { detail?: string }).detail === "string") {
+      out.push({
+        kind: "package_error",
+        error: { detail: (item.error as { detail: string }).detail },
+      });
+    } else if (
+      item?.kind === "lang_error" &&
+      typeof item.lang === "string" &&
+      item.error
+    ) {
+      const er = item.error as { detail?: string; message?: string };
+      out.push({
+        kind: "lang_error",
+        lang: item.lang,
+        error: {
+          detail: String(er.detail ?? er.message ?? JSON.stringify(item.error)),
+        },
+      });
+    } else if (item?.lang != null && item?.error != null) {
+      const er = item.error as { detail?: string; message?: string };
+      out.push({
+        kind: "lang_error",
+        lang: String(item.lang),
+        error: {
+          detail: String(er.detail ?? er.message ?? JSON.stringify(item.error)),
+        },
+      });
+    } else {
+      out.push({
+        kind: "package_error",
+        error: { detail: String((item as { detail?: string })?.detail ?? JSON.stringify(item)) },
+      });
+    }
+  }
+  return out;
+}
+
+function countLangErrors(errors: AssetSyncError[]): number {
+  return errors.filter((e) => e.kind === "lang_error").length;
+}
+
+function publishErrorToastMessage(errors: AssetSyncError[]): string {
+  const onlyPackage =
+    errors.length > 0 && errors.every((e) => e.kind === "package_error");
+  if (onlyPackage) {
+    return errors.map((e) => e.error.detail).join(" ");
+  }
+  const n = countLangErrors(errors);
+  const parts: string[] = [];
+  if (n > 0) {
+    parts.push(`${n} language(s) failed to publish`);
+  }
+  const pkgDetails = errors
+    .filter((e): e is Extract<AssetSyncError, { kind: "package_error" }> => e.kind === "package_error")
+    .map((e) => e.error.detail);
+  if (pkgDetails.length) {
+    parts.push(pkgDetails.join(" "));
+  }
+  return parts.join(". ") || "Publishing completed with issues";
+}
+
 const PublishConfirmationModal: FC<{
   onClose: () => void;
   onPublish: (slug: string, academyId?: number) => Promise<void>;
@@ -392,7 +462,7 @@ const PublishingModal: FC<{ onClose: () => void }> = ({ onClose }) => {
   // const getSyllabus = useStore((state) => state.getSyllabus);
   const currentSlug = useStore((state) => state.configObject.config.slug);
   const [deployedUrl, setDeployedUrl] = useState("");
-  const [publishErrors, setPublishErrors] = useState<Array<{ lang: string; error: any }>>([]);
+  const [publishErrors, setPublishErrors] = useState<AssetSyncError[]>([]);
 
   const handlePublish = async (slug: string, academyId?: number) => {
     try {
@@ -421,18 +491,21 @@ const PublishingModal: FC<{ onClose: () => void }> = ({ onClose }) => {
         }
       }
       const res = await publishTutorial(bctoken, token, academyId);
-      
-      // Check for errors in the response
-      if (res.errors && res.errors.length > 0) {
-        setPublishErrors(res.errors);
-        // Show warning toast if there are errors
-        toast.error(`${res.errors.length} language(s) failed to publish`);
-      } else {
+      const errs = normalizePublishErrors(res.errors);
+
+      if (res.url) {
         toast.success(t("tutorial-published-successfully"));
         Notifier.confetti();
         playEffect("success");
       }
-      
+
+      if (errs.length > 0) {
+        setPublishErrors(errs);
+        toast.error(publishErrorToastMessage(errs));
+      } else {
+        setPublishErrors([]);
+      }
+
       setDeployedUrl(res.url);
       setPublishing(false);
       await fetchExercises();
@@ -489,12 +562,41 @@ const PublishingModal: FC<{ onClose: () => void }> = ({ onClose }) => {
             {publishErrors.length > 0 && (
               <div className="flex-y gap-small padding-small bg-yellow-50 border border-yellow-200 rounded">
                 <p className="text-yellow-800 font-medium m-0">
-                  Warning: {publishErrors.length} language(s) failed to publish:
+                  {(() => {
+                    const langErrs = publishErrors.filter(
+                      (e): e is Extract<AssetSyncError, { kind: "lang_error" }> =>
+                        e.kind === "lang_error"
+                    );
+                    const pkgErrs = publishErrors.filter(
+                      (e): e is Extract<AssetSyncError, { kind: "package_error" }> =>
+                        e.kind === "package_error"
+                    );
+                    if (pkgErrs.length > 0 && langErrs.length > 0) {
+                      return t("publish-mixed-notices-heading", {
+                        defaultValue: "Publishing notices:",
+                      });
+                    }
+                    if (pkgErrs.length > 0 && langErrs.length === 0) {
+                      return t("publish-breathecode-sync-heading", {
+                        defaultValue: "Breathecode asset sync:",
+                      });
+                    }
+                    return t("publish-lang-failures-heading", {
+                      count: langErrs.length,
+                      defaultValue: `Warning: ${langErrs.length} language(s) failed to publish:`,
+                    });
+                  })()}
                 </p>
                 <ul className="text-yellow-700 text-small m-0 pl-4">
                   {publishErrors.map((err, index) => (
                     <li key={index}>
-                      <strong>{err.lang}:</strong> {err.error?.detail || err.error?.message || JSON.stringify(err.error)}
+                      {err.kind === "package_error" ? (
+                        <span>{err.error.detail}</span>
+                      ) : (
+                        <>
+                          <strong>{err.lang}:</strong> {err.error.detail}
+                        </>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/src/components/PackageMetadataListener.tsx
+++ b/src/components/PackageMetadataListener.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import useStore from "../utils/store";
+
+/**
+ * When Rigobot token and package slug are available, fetches package id from Rigobot
+ * and merges package_id into local telemetry if missing (see store.fetchPackageMetadata).
+ */
+export default function PackageMetadataListener() {
+  const token = useStore((s) => s.token);
+  const slug = useStore((s) => s.configObject?.config?.slug ?? "");
+
+  useEffect(() => {
+    if (!token?.trim() || !slug.trim()) {
+      return;
+    }
+    void useStore.getState().fetchPackageMetadata();
+  }, [token, slug]);
+
+  return null;
+}

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -740,6 +740,7 @@ interface ITelemetryManager {
   save: () => void;
   retrieve: () => Promise<ITelemetryJSONSchema | null>;
   getStep: (stepPosition: number) => TStep | null;
+  mergePackageIdIfMissing: (packageId: number | string) => void;
   /** Breathecode registry asset IDs from Rigobot package; not persisted in telemetry blob. */
   packageAssetIds: number[];
 }
@@ -1385,6 +1386,17 @@ const TelemetryManager: ITelemetryManager = {
         this.packageAssetIds
       );
       await sendBatchTelemetryRigobot(body, this.user.rigo_token);
+      const payload = body as {
+        global_metrics?: ITelemetryJSONSchema["global_metrics"];
+        global_indicators?: ITelemetryJSONSchema["global_indicators"];
+      };
+      if (payload.global_metrics !== undefined) {
+        this.current.global_metrics = payload.global_metrics;
+      }
+      if (payload.global_indicators !== undefined) {
+        this.current.global_indicators = payload.global_indicators;
+      }
+      this.save();
     } catch (error) {
       console.error("Error submitting telemetry", error);
     }
@@ -1404,6 +1416,21 @@ const TelemetryManager: ITelemetryManager = {
 
   getStep: function (stepPosition: number) {
     return this.current?.steps[stepPosition] || null;
+  },
+
+  mergePackageIdIfMissing: function (packageId: number | string) {
+    if (!this.current) {
+      return;
+    }
+    if (
+      this.current.package_id !== undefined &&
+      this.current.package_id !== null &&
+      this.current.package_id !== ""
+    ) {
+      return;
+    }
+    this.current.package_id = packageId;
+    this.save();
   },
 
   streamEvent: async function (stepPosition, event, data) {

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1429,7 +1429,7 @@ const TelemetryManager: ITelemetryManager = {
     ) {
       return;
     }
-    this.current.package_id = packageId;
+    this.current.package_id = String(packageId);
     this.save();
   },
 

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -169,6 +169,45 @@ export async function fetchLearnpackPackageAssetIds(
   }
 }
 
+/**
+ * Rigobot package record for a slug; `id` is the Learnpack package id.
+ * Returns null on network errors or non-success (does not throw).
+ */
+export async function getPackageBySlug(
+  rigoToken: string,
+  packageSlug: string
+): Promise<{ id: number | string } | null> {
+  if (!rigoToken?.trim() || !packageSlug) {
+    return null;
+  }
+
+  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${encodeURIComponent(packageSlug)}/`;
+
+  try {
+    const response = await axios.get<{ id?: unknown }>(url, {
+      headers: {
+        Authorization: `Token ${rigoToken.trim()}`,
+      },
+    });
+
+    const raw = response.data?.id;
+    if (raw === undefined || raw === null) {
+      return null;
+    }
+    const id =
+      typeof raw === "number" || typeof raw === "string"
+        ? raw
+        : Number(raw);
+    if (typeof id === "number" && !Number.isFinite(id)) {
+      return null;
+    }
+    return { id };
+  } catch (error) {
+    console.warn("getPackageBySlug failed:", error);
+    return null;
+  }
+}
+
 export const isPackageAuthor = async (
   token: string,
   packageSlug: string

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -55,6 +55,7 @@ import {
   getSession,
   updateSession,
   isPackageAuthor,
+  getPackageBySlug,
 } from "./apiCalls";
 import TelemetryManager, {
   TStep,
@@ -262,6 +263,8 @@ const useStore = create<IStore>((set, get) => ({
   showFeedback: false,
   token: "",
   bc_token: "",
+  packageId: null as number | string | null,
+  packageIdSlug: null as string | null,
   buildbuttonText: {
     text: "see-terminal-output",
     className: "",
@@ -866,6 +869,12 @@ The user's set up the application in "${language}" language, give your feedback 
 
       if (config.config.title.us) set({ lessonTitle: config.config.title.us });
 
+      const prevSlug = (get().configObject?.config?.slug ?? "").trim();
+      const newSlug = (config.config.slug ?? "").trim();
+      if (prevSlug !== "" && prevSlug !== newSlug) {
+        set({ packageId: null, packageIdSlug: null });
+      }
+
       set({ configObject: config });
 
       if (
@@ -882,6 +891,22 @@ The user's set up the application in "${language}" language, give your feedback 
       disconnected();
       return false;
     }
+  },
+  fetchPackageMetadata: async () => {
+    const { token, configObject, packageId, packageIdSlug } = get();
+    const slug = (configObject?.config?.slug ?? "").trim();
+    if (!token?.trim() || !slug) {
+      return;
+    }
+    if (slug === packageIdSlug && packageId != null) {
+      return;
+    }
+    const result = await getPackageBySlug(token, slug);
+    if (!result) {
+      return;
+    }
+    set({ packageId: result.id, packageIdSlug: slug });
+    TelemetryManager.mergePackageIdIfMissing(result.id);
   },
   checkParams: ({ justReturn }) => {
     const { setLanguage, setPosition, language, setOpenedModals } = get();
@@ -2608,6 +2633,10 @@ The user's set up the application in "${language}" language, give your feedback 
           cohort_id: params.cohort_id || "",
           academy_id: params.academy_id || "",
         });
+        const pkgId = get().packageId;
+        if (pkgId != null) {
+          TelemetryManager.mergePackageIdIfMissing(pkgId);
+        }
       } finally {
         set({ telemetryReady: true });
       }

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -1136,6 +1136,47 @@ The user's set up the application in "${language}" language, give your feedback 
     //   conversationId: conversationId,
     // });
   },
+
+  /**
+   * creatorWeb: run after successful loginToRigo (token set). Mirrors start() from
+   * fetchExercises through getSyncNotifications, except initRigoAI is NOT called here —
+   * loginToRigo already calls initRigoAI() in its try block before this. In start(), initRigoAI
+   * runs between startTelemetry and getSyllabus; omitting it here avoids a duplicate call.
+   */
+  bootstrapCreatorWebAfterAuth: async () => {
+    const {
+      fetchExercises,
+      checkParams,
+      fetchReadme,
+      initCompilerSocket,
+      startConversation,
+      setOpenedModals,
+      getOrCreateActiveSession,
+      ensureTelemetryStarted,
+      getSyllabus,
+      getSyncNotifications,
+    } = get();
+
+    const fetchOk = await fetchExercises();
+    if (fetchOk !== true) {
+      setOpenedModals({ login: false, mustLogin: false });
+      return;
+    }
+
+    const params = checkParams({ justReturn: false });
+    if (!params.currentExercise) {
+      await fetchReadme();
+    }
+    initCompilerSocket();
+    RigoAI.load();
+    startConversation(Number(get().currentExercisePosition));
+    setOpenedModals({ login: false, mustLogin: false });
+    await getOrCreateActiveSession();
+    await ensureTelemetryStarted();
+    await getSyllabus();
+    await getSyncNotifications();
+  },
+
   // @ts-ignore
   loginToRigo: async (loginInfo) => {
     const {
@@ -1149,6 +1190,8 @@ The user's set up the application in "${language}" language, give your feedback 
       ensureTelemetryStarted,
       getUserConsumables,
       initRigoAI,
+      environment,
+      bootstrapCreatorWebAfterAuth,
     } = get();
 
     try {
@@ -1189,8 +1232,13 @@ The user's set up the application in "${language}" language, give your feedback 
       }
     }
 
+    if (environment === "creatorWeb") {
+      await bootstrapCreatorWebAfterAuth();
+      return true;
+    }
+
     startConversation(Number(currentExercisePosition));
-    setOpenedModals({ login: false });
+    setOpenedModals({ login: false, mustLogin: false });
     await getOrCreateActiveSession();
     await ensureTelemetryStarted();
     return true;

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -1146,6 +1146,7 @@ The user's set up the application in "${language}" language, give your feedback 
       language,
       reportEnrichDataLayer,
       getOrCreateActiveSession,
+      ensureTelemetryStarted,
       getUserConsumables,
       initRigoAI,
     } = get();
@@ -1190,7 +1191,8 @@ The user's set up the application in "${language}" language, give your feedback 
 
     startConversation(Number(currentExercisePosition));
     setOpenedModals({ login: false });
-    getOrCreateActiveSession();
+    await getOrCreateActiveSession();
+    await ensureTelemetryStarted();
     return true;
   },
 
@@ -1237,6 +1239,18 @@ The user's set up the application in "${language}" language, give your feedback 
         };
         await fetch(`${HOST}/set-rigobot-token`, config);
       }
+
+      const {
+        token: rigoToken,
+        configObject,
+        getOrCreateActiveSession,
+        ensureTelemetryStarted,
+      } = get();
+      if (rigoToken && configObject) {
+        await getOrCreateActiveSession();
+        await ensureTelemetryStarted();
+      }
+
       return data.key;
     } catch (error) {
       console.log(error, "ERROR");
@@ -2501,8 +2515,15 @@ The user's set up the application in "${language}" language, give your feedback 
     }
   },
 
-  refreshDataFromAnotherTab: ({ newToken, newTabHash, newBCToken }) => {
-    const { token, bc_token, tabHash, getOrCreateActiveSession, initRigoAI } = get();
+  refreshDataFromAnotherTab: async ({ newToken, newTabHash, newBCToken }) => {
+    const {
+      token,
+      bc_token,
+      tabHash,
+      getOrCreateActiveSession,
+      initRigoAI,
+      ensureTelemetryStarted,
+    } = get();
 
     if (!(token === newToken)) {
       set({ token: newToken });
@@ -2513,8 +2534,9 @@ The user's set up the application in "${language}" language, give your feedback 
     if (!(tabHash === newTabHash)) {
       set({ tabHash: newTabHash });
     }
-    getOrCreateActiveSession();
+    await getOrCreateActiveSession();
     initRigoAI();
+    await ensureTelemetryStarted();
   },
   toggleTheme: () => {
     const { theme, checkParams } = get();
@@ -2625,6 +2647,9 @@ The user's set up the application in "${language}" language, give your feedback 
 
       const params = checkParams({ justReturn: true });
 
+      const skipDuplicateBootstrap =
+        TelemetryManager.started && TelemetryManager.current != null;
+
       try {
         await TelemetryManager.start(agent, steps, tutorialSlug, STORAGE_KEY, {
           token: bc_token,
@@ -2638,8 +2663,11 @@ The user's set up the application in "${language}" language, give your feedback 
         if (pkgId != null) {
           TelemetryManager.mergePackageIdIfMissing(pkgId);
         }
-      } finally {
         set({ telemetryReady: true });
+      } catch (error) {
+        console.error("Failed to start telemetry", error);
+        set({ telemetryReady: false });
+        return;
       }
 
       if (agent === "cloud" && !telemetryLifecycleListenersRegistered) {
@@ -2665,34 +2693,39 @@ The user's set up the application in "${language}" language, give your feedback 
         window.addEventListener("pagehide", onUnload);
       }
 
-      TelemetryManager.registerListener(
-        "compile_struggles",
-        (stepIndicators) => {
-          console.log(stepIndicators, "In compile struggles");
-        }
-      );
-      TelemetryManager.registerListener("test_struggles", (stepIndicators) => {
-        if (
-          stepIndicators.metrics.streak_test_struggle === 3 ||
-          stepIndicators.metrics.streak_test_struggle === 9 ||
-          stepIndicators.metrics.streak_test_struggle >= 15
-        ) {
-          setOpenedModals({ testStruggles: true });
-        }
-      });
-
-      const openingPosition = Number(currentExercisePosition);
-      if (typeof openingPosition === "number" && !isNaN(openingPosition)) {
-        registerTelemetryEvent("open_step", {
-          step_slug: steps[openingPosition].slug,
-          step_position: steps[openingPosition].position,
-        });
-      } else {
-        console.error(
-          "Current exercise position is not a number, telemetry won't start, open step not registered"
+      if (!skipDuplicateBootstrap) {
+        TelemetryManager.registerListener(
+          "compile_struggles",
+          (stepIndicators) => {
+            console.log(stepIndicators, "In compile struggles");
+          }
         );
+        TelemetryManager.registerListener("test_struggles", (stepIndicators) => {
+          if (
+            stepIndicators.metrics.streak_test_struggle === 3 ||
+            stepIndicators.metrics.streak_test_struggle === 9 ||
+            stepIndicators.metrics.streak_test_struggle >= 15
+          ) {
+            setOpenedModals({ testStruggles: true });
+          }
+        });
+
+        const openingPosition = Number(currentExercisePosition);
+        if (typeof openingPosition === "number" && !isNaN(openingPosition)) {
+          registerTelemetryEvent("open_step", {
+            step_slug: steps[openingPosition].slug,
+            step_position: steps[openingPosition].position,
+          });
+        } else {
+          console.error(
+            "Current exercise position is not a number, telemetry won't start, open step not registered"
+          );
+        }
       }
     }
+  },
+  ensureTelemetryStarted: () => {
+    return get().startTelemetry();
   },
   setRigoContext: (context) => {
     const { rigoContext } = get();

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -263,7 +263,7 @@ const useStore = create<IStore>((set, get) => ({
   showFeedback: false,
   token: "",
   bc_token: "",
-  packageId: null as number | string | null,
+  packageId: null as string | null,
   packageIdSlug: null as string | null,
   buildbuttonText: {
     text: "see-terminal-output",
@@ -905,8 +905,9 @@ The user's set up the application in "${language}" language, give your feedback 
     if (!result) {
       return;
     }
-    set({ packageId: result.id, packageIdSlug: slug });
-    TelemetryManager.mergePackageIdIfMissing(result.id);
+    const idStr = String(result.id);
+    set({ packageId: idStr, packageIdSlug: slug });
+    TelemetryManager.mergePackageIdIfMissing(idStr);
   },
   checkParams: ({ justReturn }) => {
     const { setLanguage, setPosition, language, setOpenedModals } = get();

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -377,7 +377,12 @@ export interface IStore {
   setFeedbackButtonProps: (t: string, c: string) => void;
   fetchSingleExerciseInfo: (index: number) => Promise<TExercise>;
   toggleFeedback: () => void;
-  fetchExercises: () => void;
+  fetchExercises: () => Promise<boolean | void>;
+  /**
+   * creatorWeb: after loginToRigo succeeds, mirrors start() post-fetch (see store implementation comment).
+   * Do not call from other environments.
+   */
+  bootstrapCreatorWebAfterAuth: () => Promise<void>;
   /** GET package metadata from Rigobot when token and config slug exist; merges package_id into telemetry if missing. */
   fetchPackageMetadata: () => Promise<void>;
   updateEditorTabs: () => void;

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -364,7 +364,7 @@ export interface IStore {
   getContextFilesContent: () => Promise<string>;
   loginToRigo: (loginInfo: TLoginInfo) => Promise<void | false>;
   getCurrentExercise: () => TExercise;
-  refreshDataFromAnotherTab: (data: TRefreshData) => void;
+  refreshDataFromAnotherTab: (data: TRefreshData) => Promise<void>;
   setExerciseMessages: (messages: IMessage[], position: number) => void;
   setShowVideoTutorial: (show: boolean) => void;
   registerTelemetryEvent: (event: TStepEvent, data: object) => void;
@@ -386,6 +386,8 @@ export interface IStore {
   setLessonSyncInProgress: (slug: string | null) => void;
   syncLessonFilesFromEditor: (lessonSlug: string) => Promise<void>;
   startTelemetry: () => Promise<void>;
+  /** Idempotent wrapper; call after login or late session sync when bootstrap skipped telemetry. */
+  ensureTelemetryStarted: () => Promise<void>;
   build: (buildText: string, submittedInputs?: string[]) => void;
   setPosition: (position: number) => void;
   fetchReadme: () => void;
@@ -415,7 +417,7 @@ export interface IStore {
   // registerAIInteraction: (setPosition: number, interaction: object) => void;
   sessionActions: (opts: TSessionActionsOpts) => void;
   displayTestButton: boolean;
-  /** True after TelemetryManager.start() has finished (cloud reconciliation included). */
+  /** True after TelemetryManager.start() completes without throwing (cloud reconciliation included). */
   telemetryReady: boolean;
   getOrCreateActiveSession: () => void;
   updateDBSession: () => void;

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -283,8 +283,8 @@ export interface IStore {
   user: TUser;
   token: string;
   bc_token: string;
-  /** Rigobot Learnpack package id for the current course slug; null until resolved. */
-  packageId: number | string | null;
+  /** Rigobot Learnpack package id for the current course slug; null until resolved. Always string when set. */
+  packageId: string | null;
   /** Slug for which `packageId` is valid; used to skip refetch and to invalidate on course change. */
   packageIdSlug: string | null;
   assessmentConfig: TAssessmentConfig;

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -283,6 +283,10 @@ export interface IStore {
   user: TUser;
   token: string;
   bc_token: string;
+  /** Rigobot Learnpack package id for the current course slug; null until resolved. */
+  packageId: number | string | null;
+  /** Slug for which `packageId` is valid; used to skip refetch and to invalidate on course change. */
+  packageIdSlug: string | null;
   assessmentConfig: TAssessmentConfig;
   configObject: IConfigObject;
   videoTutorial: string;
@@ -374,6 +378,8 @@ export interface IStore {
   fetchSingleExerciseInfo: (index: number) => Promise<TExercise>;
   toggleFeedback: () => void;
   fetchExercises: () => void;
+  /** GET package metadata from Rigobot when token and config slug exist; merges package_id into telemetry if missing. */
+  fetchPackageMetadata: () => Promise<void>;
   updateEditorTabs: () => void;
   setFileLoadNotFound: (lessonSlug: string, filename: string, notFound: boolean) => void;
   clearFileLoadNotFoundForLesson: (lessonSlug: string) => void;


### PR DESCRIPTION
⚠️ Require this PR in CLI:  [feat(publish): send learnpack_id to Breathecode and harden publish flow](https://github.com/learnpack/learnpack-cli/pull/198)

---

- Model publish `errors` as discriminated `AssetSyncError` (lang vs package).
- Normalize legacy `{ lang, error }` responses for backward compatibility.
- Show success toast/confetti when the package URL is returned; surface sync
  issues with clearer toasts and modal copy for package-level failures.