### PR TITLE
Fix: telemetría sin package_id ni asset_ids para usuarios no-owner

### DIFF
--- a/.agents/skills/telemetry/SKILL.md
+++ b/.agents/skills/telemetry/SKILL.md
@@ -11,7 +11,7 @@ description: >
   hasPendingTasks, is_completed, testeable_elements, quiz_submission, open_step,
   reconcileTelemetry, normalizeTelemetrySchema, workout_session, lesson_rendered,
   completeStepIfReadOnly, onLessonRendered, activeHashes, package_id,
-  mergePackageIdIfMissing, fetchPackageMetadata, getPackageBySlug,
+  mergePackageIdIfMissing, fetchPackageMetadata, fetchLearnpackPackageInfo,
   PackageMetadataListener, ensureTelemetryStarted, global_metrics, global_indicators, or anything related to
   completion_rate, step tracking, or telemetry submission/persistence.
 ---
@@ -113,8 +113,8 @@ For compilation/test events, data must be base64-encoded (see `stringToBase64` /
 
 **`package_id` — optional Rigobot lookup and merge (not part of `start()` itself):**
 - The persisted blob may already contain `package_id` (localStorage, server GET, or prior sessions). It is **whitelisted** (`TELEMETRY_WHITELIST_KEYS`).
-- When missing or empty, the IDE resolves the LearnPack package record **via HTTP**: `getPackageBySlug()` → `GET ${RIGOBOT_HOST}/v1/learnpack/package/<slug>/` (same path used for `asset_ids`; see `references/apis.md`). The response `id` is stored in Zustand as **`packageId` + `packageIdSlug`** (`src/utils/store.tsx` / `storeTypes.ts`).
-- **`PackageMetadataListener`** (`src/components/PackageMetadataListener.tsx`, mounted in `App.tsx`) runs when **Rigobot token + config slug** are set; it calls **`fetchPackageMetadata()`**, which skips the network if the slug still matches the cached `packageIdSlug` with a non-null `packageId`, otherwise fetches and calls **`TelemetryManager.mergePackageIdIfMissing(idStr)`**.
+- When missing or empty, `TelemetryManager.start()` calls **`fetchLearnpackPackageInfo()`** → `GET ${RIGOBOT_HOST}/v1/learnpack/package/<slug>/assets/` and **`mergePackageIdIfMissing(id)`** after reconciliation (see `references/apis.md`). The `id` can also be stored in Zustand as **`packageId` + `packageIdSlug`** via **`fetchPackageMetadata()`** (`src/utils/store.tsx` / `storeTypes.ts`).
+- **`PackageMetadataListener`** (`src/components/PackageMetadataListener.tsx`, mounted in `App.tsx`) runs when **Rigobot token + config slug** are set; it calls **`fetchPackageMetadata()`**, which skips the network if the slug still matches the cached `packageIdSlug` with a non-null `packageId`, otherwise fetches and calls **`TelemetryManager.mergePackageIdIfMissing(idStr)`** (same HTTP helper as `start()`; idempotent if `package_id` already set).
 - **`startTelemetry()`** after `await TelemetryManager.start(...)` calls **`mergePackageIdIfMissing(pkgId)`** again if the store already has `packageId` — this covers ordering where metadata resolved before telemetry finished bootstrapping.
 - **`mergePackageIdIfMissing`** only writes when `current.package_id` is missing/empty; it always stores a **string** (`String(packageId)`). The schema allows `number | string`; the IDE normalizes new fills to **string**.
 - **Course change:** inside **`fetchExercises`**, if the incoming config slug **differs** from the previous non-empty slug, the store clears **`packageId` / `packageIdSlug`** so the next listener/metadata pass targets the new package.

--- a/.agents/skills/telemetry/references/apis.md
+++ b/.agents/skills/telemetry/references/apis.md
@@ -60,14 +60,24 @@ Body: ITelemetryJSONSchema (full blob with computed metrics)
 
 ---
 
-### GET /v1/learnpack/package/${slug}/
+### GET /v1/learnpack/package/${slug}/assets/
 
-**Purpose:** Package metadata on Rigobot — `asset_ids`, **`id`** (LearnPack package id), author checks, etc.
+**Purpose:** **Student-safe** package metadata: **`id`** (LearnPack package id) and **`asset_ids`** (Breathecode asset IDs for the batch query param). Any authenticated Rigobot user (not only package owner).
 
-**Used in:**
+**Used in:** `src/utils/apiCalls.ts` — **`fetchLearnpackPackageInfo()`** — single call; returns `{ id, assetIds }` (no throw; empty on 404 or error).
 
-- `src/utils/apiCalls.ts` — `isPackageAuthor` (status 200 vs 404); `fetchLearnpackPackageAssetIds()` parses `asset_ids` for telemetry batch (Breathecode query param only).
-- **`getPackageBySlug()`** — reads **`id`** from the JSON body for Zustand (`packageId` / `packageIdSlug`) and for **`TelemetryManager.mergePackageIdIfMissing`**. Does **not** throw on failure; returns `null` on errors or missing `id`.
+```
+GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/assets/
+
+Headers:
+  Authorization: Token <rigobot_token>
+```
+
+During `TelemetryManager.start()` (cloud and local agents), the IDE calls **`fetchLearnpackPackageInfo`** when `rigo_token` and package slug are present, sets `TelemetryManager.packageAssetIds` from `assetIds`, and calls **`mergePackageIdIfMissing(id)`** after `this.current` exists (reconciliation done). **PackageMetadataListener** → **`fetchPackageMetadata()`** uses the same function as a fallback when the store’s `packageId` is not yet set.
+
+### GET /v1/learnpack/package/${slug}/ (owner / legacy)
+
+**Purpose:** Full package record; **may return 403** for non-owners. Still used for **`isPackageAuthor`** (creator web).
 
 ```
 GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
@@ -75,10 +85,6 @@ GET ${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/
 Headers:
   Authorization: Token <rigobot_token>
 ```
-
-During `TelemetryManager.start()` (cloud and local agents), the IDE loads `asset_ids` **once** via `fetchLearnpackPackageAssetIds` when `rigo_token` and package slug are present. IDs are kept in memory (`TelemetryManager.packageAssetIds`), not in the persisted telemetry blob.
-
-**Package id for the telemetry blob** is filled separately: **`PackageMetadataListener`** → **`fetchPackageMetadata()`** → **`getPackageBySlug()`** → **`mergePackageIdIfMissing`**. Same URL as above; independent of the `asset_ids` fetch used for Breathecode `asset_id` query params.
 
 ---
 

--- a/.agents/skills/telemetry/references/key-files.md
+++ b/.agents/skills/telemetry/references/key-files.md
@@ -40,7 +40,7 @@ The heart of all telemetry logic in the IDE.
 | 530, 547 | Compile handlers → `registerTelemetryEvent("compile", ...)` |
 | 1069, 2656 | `registerTelemetryEvent("open_step", ...)` |
 | ~872–876 | `fetchExercises` — if config **slug** changes from a previous non-empty value, clears `packageId` / `packageIdSlug` |
-| ~895–911 | `fetchPackageMetadata` — `getPackageBySlug`, cache by slug, `mergePackageIdIfMissing` |
+| ~895–911 | `fetchPackageMetadata` — `fetchLearnpackPackageInfo`, cache by slug, `mergePackageIdIfMissing` |
 | `startTelemetry` | Assigns `TelemetryManager.urls`, `skipDuplicateBootstrap` guard, `await TelemetryManager.start()`, `mergePackageIdIfMissing` if store `packageId` set; `telemetryReady` only on success; initial struggle listeners + `open_step` only when not skipping duplicate bootstrap |
 | `ensureTelemetryStarted` | Delegates to `startTelemetry()` — call after **`loginToRigo`**, **`refreshDataFromAnotherTab`**, **`checkRigobotInvitation`** when session arrives after bootstrap |
 | `loginToRigo` / `refreshDataFromAnotherTab` / `checkRigobotInvitation` | Late session: `await getOrCreateActiveSession()` then `await ensureTelemetryStarted()` (plus `initRigoAI` in `refreshDataFromAnotherTab`) |
@@ -105,8 +105,7 @@ The heart of all telemetry logic in the IDE.
 
 ### `src/utils/apiCalls.ts`
 
-- `fetchLearnpackPackageAssetIds()` — GET Rigobot package, returns `asset_ids` as `number[]` for Breathecode batch URL (telemetry bootstrap).
-- `getPackageBySlug()` — GET same package URL; returns `{ id }` or `null` (no throw); used for `package_id` merge path.
+- `fetchLearnpackPackageInfo()` — GET `.../package/<slug>/assets/`; returns `{ id, assetIds }` for Breathecode batch query param and `package_id` merge (telemetry bootstrap and `PackageMetadataListener`).
 
 ### `src/App.tsx`
 - Renders `<PackageMetadataListener />` next to other global listeners.

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -14,7 +14,7 @@ import { TAgent } from "../utils/storeTypes";
 import { LEARNPACK_LOCAL_URL } from "../utils/creator";
 import { debounce, RIGOBOT_HOST } from "../utils/lib";
 import { eventBus } from "./eventBus";
-import { fetchLearnpackPackageAssetIds } from "../utils/apiCalls";
+import { fetchLearnpackPackageInfo } from "../utils/apiCalls";
 
 export interface IFile {
   path: string;
@@ -771,14 +771,6 @@ const TelemetryManager: ITelemetryManager = {
   },
 
   start: function (agent, steps, tutorialSlug, storageKey, student) {
-    console.log("[TEL_DEBUG] start() called", {
-      alreadyStarted: this.started,
-      hasCurrent: !!this.current,
-      hasRigoToken: !!student.rigo_token?.trim(),
-      tutorialSlug,
-      agent,
-    });
-
     this.activeHashes = new Map<string, Set<string>>();
     this.packageAssetIds = [];
     this.telemetryKey = storageKey;
@@ -791,7 +783,6 @@ const TelemetryManager: ITelemetryManager = {
     // Email removed for security - not stored in telemetry
 
     if (this.current) {
-      console.warn("[TEL_DEBUG] start() EARLY RETURN — this.current already set, packageAssetIds reset to []");
       return Promise.resolve();
     }
 
@@ -804,10 +795,9 @@ const TelemetryManager: ITelemetryManager = {
           const localTelemetry =
             localRaw && localRaw.slug === tutorialSlug ? localRaw : null;
 
-          const willFetchAssetIds = !!(student.rigo_token?.trim() && tutorialSlug);
-          console.log("[TEL_DEBUG] cloud Promise.all — willFetchAssetIds:", willFetchAssetIds, "slug:", tutorialSlug);
+          const willFetchPackage = !!(student.rigo_token?.trim() && tutorialSlug);
 
-          const [serverTelemetry, packageAssetIds] = await Promise.all([
+          const [serverTelemetry, packageInfo] = await Promise.all([
             student.rigo_token && student.user_id
               ? fetchTelemetryFromServer({
                   userId: student.user_id,
@@ -815,16 +805,15 @@ const TelemetryManager: ITelemetryManager = {
                   rigoToken: student.rigo_token,
                 })
               : Promise.resolve(null as ITelemetryJSONSchema | null),
-            willFetchAssetIds
-              ? fetchLearnpackPackageAssetIds(
+            willFetchPackage
+              ? fetchLearnpackPackageInfo(
                   student.rigo_token,
                   tutorialSlug
                 )
-              : Promise.resolve([] as number[]),
+              : Promise.resolve({ id: null, assetIds: [] as number[] }),
           ]);
 
-          console.log("[TEL_DEBUG] cloud Promise.all resolved — packageAssetIds:", packageAssetIds);
-          this.packageAssetIds = packageAssetIds;
+          this.packageAssetIds = packageInfo.assetIds;
 
           const { telemetry, source } = reconcileTelemetry(
             serverTelemetry,
@@ -843,6 +832,10 @@ const TelemetryManager: ITelemetryManager = {
 
           if (!this.current.version) {
             this.current.version = `CLOUD:${this.version}`;
+          }
+
+          if (packageInfo.id != null) {
+            this.mergePackageIdIfMissing(packageInfo.id);
           }
 
           this.finishWorkoutSession();
@@ -936,10 +929,14 @@ const TelemetryManager: ITelemetryManager = {
         }
 
         if (this.user.rigo_token?.trim() && tutorialSlug) {
-          this.packageAssetIds = await fetchLearnpackPackageAssetIds(
+          const packageInfo = await fetchLearnpackPackageInfo(
             this.user.rigo_token,
             tutorialSlug
           );
+          this.packageAssetIds = packageInfo.assetIds;
+          if (packageInfo.id != null) {
+            this.mergePackageIdIfMissing(packageInfo.id);
+          }
         }
 
         await this.submit();
@@ -1388,8 +1385,6 @@ const TelemetryManager: ITelemetryManager = {
       console.error("Batch URL is required to send telemetry");
       return;
     }
-
-    console.log("[TEL_DEBUG] submit() — packageAssetIds:", this.packageAssetIds, "package_id:", this.current.package_id, "batchUrl:", url);
 
     const body = buildSubmitPayload(this.current, this.user.id);
 

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -141,70 +141,38 @@ function normalizeLearnpackPackageAssetIds(raw: unknown): number[] {
 }
 
 /**
- * Breathecode asset IDs for telemetry batch query param; sourced from Rigobot package record.
+ * Package id and Breathecode asset_ids for telemetry; accessible to any authenticated Rigobot user
+ * (unlike GET /v1/learnpack/package/{slug}/, which is owner-only).
  */
-export async function fetchLearnpackPackageAssetIds(
+export async function fetchLearnpackPackageInfo(
   rigoToken: string,
   packageSlug: string
-): Promise<number[]> {
+): Promise<{ id: string | null; assetIds: number[] }> {
+  const empty = { id: null, assetIds: [] as number[] };
   if (!rigoToken?.trim() || !packageSlug) {
-    return [];
+    return empty;
   }
 
-  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${encodeURIComponent(packageSlug)}/`;
+  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${encodeURIComponent(packageSlug)}/assets/`;
 
   try {
-    const response = await axios.get<{ asset_ids?: unknown }>(url, {
+    const response = await axios.get<{
+      id?: unknown;
+      asset_ids?: unknown;
+    }>(url, {
       headers: {
         Authorization: `Token ${rigoToken.trim()}`,
       },
     });
-    return normalizeLearnpackPackageAssetIds(response.data?.asset_ids);
+    const raw = response.data;
+    const id = raw?.id != null ? String(raw.id) : null;
+    return { id, assetIds: normalizeLearnpackPackageAssetIds(raw?.asset_ids) };
   } catch (error) {
     if (axios.isAxiosError(error) && error.response?.status === 404) {
-      return [];
+      return empty;
     }
-    console.warn("fetchLearnpackPackageAssetIds failed:", error);
-    return [];
-  }
-}
-
-/**
- * Rigobot package record for a slug; `id` is the Learnpack package id.
- * Returns null on network errors or non-success (does not throw).
- */
-export async function getPackageBySlug(
-  rigoToken: string,
-  packageSlug: string
-): Promise<{ id: number | string } | null> {
-  if (!rigoToken?.trim() || !packageSlug) {
-    return null;
-  }
-
-  const url = `${RIGOBOT_HOST}/v1/learnpack/package/${encodeURIComponent(packageSlug)}/`;
-
-  try {
-    const response = await axios.get<{ id?: unknown }>(url, {
-      headers: {
-        Authorization: `Token ${rigoToken.trim()}`,
-      },
-    });
-
-    const raw = response.data?.id;
-    if (raw === undefined || raw === null) {
-      return null;
-    }
-    const id =
-      typeof raw === "number" || typeof raw === "string"
-        ? raw
-        : Number(raw);
-    if (typeof id === "number" && !Number.isFinite(id)) {
-      return null;
-    }
-    return { id };
-  } catch (error) {
-    console.warn("getPackageBySlug failed:", error);
-    return null;
+    console.warn("fetchLearnpackPackageInfo failed:", error);
+    return empty;
   }
 }
 

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -55,7 +55,7 @@ import {
   getSession,
   updateSession,
   isPackageAuthor,
-  getPackageBySlug,
+  fetchLearnpackPackageInfo,
 } from "./apiCalls";
 import TelemetryManager, {
   TStep,
@@ -901,11 +901,11 @@ The user's set up the application in "${language}" language, give your feedback 
     if (slug === packageIdSlug && packageId != null) {
       return;
     }
-    const result = await getPackageBySlug(token, slug);
-    if (!result) {
+    const result = await fetchLearnpackPackageInfo(token, slug);
+    if (!result.id) {
       return;
     }
-    const idStr = String(result.id);
+    const idStr = result.id;
     set({ packageId: idStr, packageIdSlug: slug });
     TelemetryManager.mergePackageIdIfMissing(idStr);
   },
@@ -2708,7 +2708,6 @@ The user's set up the application in "${language}" language, give your feedback 
           academy_id: params.academy_id || "",
         });
         const pkgId = get().packageId;
-        console.log("[TEL_DEBUG] startTelemetry after start() — packageId in store:", pkgId, "TM.packageAssetIds:", TelemetryManager.packageAssetIds);
         if (pkgId != null) {
           TelemetryManager.mergePackageIdIfMissing(pkgId);
         }


### PR DESCRIPTION
⚠️ Requiere [Nuevo endpoint para devolver package_id y asset_ids de un paquete a usuarios no-owners (para telemetría en IDE)](https://github.com/breatheco-de/rigobot/pull/370)

---

## Problema
Los alumnos que abrían un paquete sin sesión activa y luego iniciaban sesión
recibían un 403 al intentar obtener los datos del paquete desde
`GET /v1/learnpack/package/<slug>/`, un endpoint de Rigobot restringido a owners.
Esto provocaba que la telemetría se enviara sin `package_id` ni `asset_id`
en la URL del POST a Breathecode.

## Solución
Se reemplazaron `fetchLearnpackPackageAssetIds` y `getPackageBySlug` por
`fetchLearnpackPackageInfo`, que usa el nuevo endpoint de Rigobot
`GET /v1/learnpack/package/<slug>/assets/` accesible para cualquier usuario
autenticado y devuelve `id` y `asset_ids` en una sola llamada.