### PR TITLE
Simplificar lógica de completado y mejorar UI del sidebar

### DIFF
--- a/src/components/composites/Editor/Editor.tsx
+++ b/src/components/composites/Editor/Editor.tsx
@@ -22,6 +22,7 @@ import { Loader } from "../Loader/Loader";
 import { TEditorTab } from "../../../utils/storeTypes";
 import { Markdowner } from "../Markdowner/Markdowner";
 import { eventBus } from "../../../managers/eventBus";
+import TelemetryManager from "../../../managers/telemetry";
 import { Modal } from "../../mockups/Modal";
 import { deleteFile } from "../../../utils/creator";
 import { Icon } from "../../Icon";
@@ -1174,9 +1175,26 @@ const NextButton = () => {
     exercises: state.exercises,
   }));
 
+  const isLastExercise = currentExercisePosition === exercises.length - 1;
+
+  if (isLastExercise) {
+    const hasPendingTasksInAnyLesson = TelemetryManager.hasPendingTasksInAnyLesson();
+    return (
+      <SimpleButton
+        disabled={hasPendingTasksInAnyLesson}
+        action={() => {
+          if (!hasPendingTasksInAnyLesson) {
+            eventBus.emit("last_lesson_finished", {});
+          }
+        }}
+        text={"Finish"}
+        extraClass="w-100 bg-success text-white big"
+      />
+    );
+  }
+
   return (
     <SimpleButton
-      disabled={currentExercisePosition === exercises.length - 1}
       action={() =>
         eventBus.emit("position_change", {
           position: Number(currentExercisePosition) + 1,

--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -424,8 +424,7 @@ function ExerciseCard({
   const current = getCurrentExercise();
   const isCurrent = current.slug === slug;
 
-  const isDone = TelemetryManager.isTesteable(position) && TelemetryManager.isStepCompleted(position);
-  const isTesteable = TelemetryManager.isTesteable(position);
+  const isDone = TelemetryManager.isStepCompleted(position);
 
 
   return (
@@ -507,7 +506,7 @@ function ExerciseCard({
               svg={svgs.pause}
             />
           )}
-        {mode === "student" && isTesteable && (
+        {mode === "student" && (
           <SimpleButton
             svg={isDone ? <Icon className="text-green-500" size={20} name="Check" /> : <Icon className="text-gray-500" size={15} name="Circle" />}
             text=""

--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -506,7 +506,7 @@ function ExerciseCard({
               svg={svgs.pause}
             />
           )}
-        {mode === "student" && (
+        {mode === "student" && TelemetryManager.current !== null && (
           <SimpleButton
             svg={isDone ? <Icon className="text-green-500" size={20} name="Check" /> : <Icon className="text-gray-500" size={15} name="Circle" />}
             text=""

--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -425,6 +425,7 @@ function ExerciseCard({
   const isCurrent = current.slug === slug;
 
   const isDone = TelemetryManager.isStepCompleted(position);
+  const isTesteableAndDone = isDone && TelemetryManager.isTesteable(position);
 
 
   return (
@@ -481,7 +482,7 @@ function ExerciseCard({
               }
             }}
           >
-            <button className={`exercise-circle ${isDone ? "done" : ""}`}>
+            <button className={`exercise-circle ${isTesteableAndDone ? "done" : ""}`}>
               <span>{id}</span>
             </button>
             <span>{formattedTitle}</span>

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1088,7 +1088,7 @@ const TelemetryManager: ITelemetryManager = {
 
   /**
    * Called (via eventBus "lesson_rendered") after the markdown content has
-   * rendered in the browser.  A debounce of 3 seconds gives quiz/FITB/OQ
+   * rendered in the browser.  A debounce of 5 seconds gives quiz/FITB/OQ
    * components time to mount and register their testeable_elements.  If
    * after the debounce the step still has no testeable_elements and is not
    * a code-test step, it is genuinely read-only and can be completed.
@@ -1104,7 +1104,7 @@ const TelemetryManager: ITelemetryManager = {
       this._lessonRenderedDebounce.cancel();
     }
 
-    const READOLY_COMPLETION_DELAY_MS = 7000;
+    const READOLY_COMPLETION_DELAY_MS = 5000;
 
     this._lessonRenderedDebounce = debounce(() => {
       this.completeStepIfReadOnly(stepPosition);

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1376,10 +1376,7 @@ const TelemetryManager: ITelemetryManager = {
     if (!this.current || !this.current.steps) {
       return false;
     }
-    return this.current.steps.some(
-      (step) =>
-        (step.is_testeable || step.testeable_elements?.length) && !step.is_completed
-    );
+    return this.current.steps.some((step) => !step.is_completed);
   },
 
   submit: async function () {

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1011,7 +1011,6 @@ const TelemetryManager: ITelemetryManager = {
     if (!this.current) {
       return
     }
-    console.log("➡️registerTesteableElement language: ", language);
 
     // Chequea si el elemento ya existe en otro step
     const existsInOtherStep = this.current.steps.findIndex(
@@ -1339,6 +1338,11 @@ const TelemetryManager: ITelemetryManager = {
     const step = this.current?.steps[stepPosition];
     if (!step?.testeable_elements?.length) return false;
 
+    // Persisted completion wins over activeHashes (session-only). Without this,
+    // revisiting a completed step in another language after telemetry restart
+    // wrongly reports pending tasks because the new locale's quiz hash is not complete.
+    if (step.is_completed) return false;
+
     // Tests are language-independent: if any is incomplete, the step is not done
     const hasIncompleteTests = step.testeable_elements.some(
       (e) => e.type === "test" && !e.is_completed
@@ -1349,19 +1353,15 @@ const TelemetryManager: ITelemetryManager = {
     const quizElements = step.testeable_elements.filter((e) => e.type === "quiz");
     if (quizElements.length === 0) return false;
 
-    console.log("➡️activeHashes: ", this.activeHashes);
-    console.log("➡️quizElements: ", quizElements);
     for (const [, hashes] of this.activeHashes) {
       const relevantHashes = [...hashes].filter((h) =>
         quizElements.some((e) => e.hash === h)
       );
-      console.log("➡️relevantHashes: ", relevantHashes);
       if (relevantHashes.length === 0) continue;
 
       const allDone = relevantHashes.every(
         (hash) => quizElements.find((e) => e.hash === hash)?.is_completed === true
       );
-      console.log("➡️allDone: ", allDone);
       if (allDone) return false;
     }
 


### PR DESCRIPTION
  - `hasPendingTasksInAnyLesson` ahora bloquea Finish si cualquier step tiene `is_completed=false`, resolviendo el caso de
  steps con quizzes nunca visitados
  - El sidebar muestra el indicador de progreso (círculo/check) para todos los steps, no solo los que tienen
  `testeable_elements` registrados
  - El badge del ID solo adopta el estilo "completado" (fondo azul) en steps con contenido testeable
  - Se agrega guard `TelemetryManager.current !== null` para evitar mostrar círculos cuando telemetría no ha iniciado
  - Si el último step tiene ejercicio de código, el botón Next del Editor pasa a tener texto y lógica de botón Finish.
