### PR TITLE
fix(telemetry): recalculate global_metrics on save before persisting

### DIFF
--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1430,6 +1430,11 @@ const TelemetryManager: ITelemetryManager = {
       return;
     }
 
+    // Recalculate aggregated metrics/indicators derived from steps before persisting.
+    const indicators = calculateIndicators(this.current);
+    this.current.global_metrics = indicators.global.metrics;
+    this.current.global_indicators = indicators.global.indicators;
+
     if (this.agent === "os" || this.agent === "vscode") {
       saveInCLI(this.current);
     } else {


### PR DESCRIPTION
Ensure global_metrics and global_indicators are derived from current steps when writing to localStorage or the CLI so stored telemetry stays in sync.