### PR TITLE
Chequear user_id al inicializar telemetría

### DIFF
--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -792,8 +792,14 @@ const TelemetryManager: ITelemetryManager = {
         let submitLocalIfNewer = false;
         try {
           const localRaw = LocalStorage.get(this.telemetryKey);
+          const localBelongsToCurrentUser =
+            localRaw?.user_id ||
+            student.user_id ||
+            String(localRaw.user_id) === String(student.user_id);
           const localTelemetry =
-            localRaw && localRaw.slug === tutorialSlug ? localRaw : null;
+            localRaw && localRaw.slug === tutorialSlug && localBelongsToCurrentUser
+              ? localRaw
+              : null;
 
           const willFetchPackage = !!(student.rigo_token?.trim() && tutorialSlug);
 


### PR DESCRIPTION
## Problema que resuelve
- En `TelemetryManager.start()`, al leer el blob local de localStorage, no se verificaba que el `user_id` almacenado correspondiera al usuario actual. 
- Esto podía provocar que, durante la reconciliación, el avance de un usuario previo (pasos completados, quiz_submissions, etc.) sustituyera el avance del usuario entrante.
- Edge case donde se podría dar el error: 
   - impersonación
   - SI usuario anterior abrió recientemente el mismo paquete en el mismo navegador
   - Y el servidor devolvía telemetría vacía O con un `last_interaction_at` anterior al del blob local

## Solución
El blob local ahora solo se acepta si ambos lados (`localRaw.user_id` y `student.user_id`) están presentes y coinciden. En caso contrario, se descarta y se crea una telemetría limpia para el usuario actual.