### PR TITLE
fix(markdowner): prevent double tab and add style to normal links

### DIFF
--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -204,7 +204,14 @@ export const Markdowner = ({
                 return <CommunityLink />;
               }
               return (
-                <a onClick={() => openLink(href)} target="_blank" href={href}>
+                <a
+                  className="link"
+                  href={href}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    openLink(href);
+                  }}
+                >
                   {children}
                 </a>
               );

--- a/src/index.css
+++ b/src/index.css
@@ -267,6 +267,16 @@ a {
   word-break: break-all;
 }
 
+a.link {
+  color: var(--color-blue-rigo);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a.link:hover {
+  text-decoration: underline;
+}
+
 /* This will affect the entire webpage */
 ::-webkit-scrollbar {
   width: 5px;


### PR DESCRIPTION
- Add e.preventDefault() on normal link onClick to avoid browser opening a second tab alongside the one opened by the socket
- Remove target="_blank" (redundant with socket-based link handling)
- Apply `.link` class with theme blue color and underline on hover