### PR TITLE
fix(sync-syllabus): include fixedLessons count in sync toast notification

### DIFF
--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -245,7 +245,8 @@ export default function ExercisesList({ closeSidebar, mode }: IExerciseList) {
       const totalChanges =
         (result.removedLessons || 0) +
         (result.duplicatesResolved || 0) +
-        (result.addedLessons || 0);
+        (result.addedLessons || 0) +
+        (result.fixedLessons || 0);
 
       if (totalChanges > 0) {
         const messages = [];
@@ -257,6 +258,9 @@ export default function ExercisesList({ closeSidebar, mode }: IExerciseList) {
         }
         if (result.addedLessons > 0) {
           messages.push(`${result.addedLessons} added from bucket`);
+        }
+        if (result.fixedLessons > 0) {
+          messages.push(`${result.fixedLessons} status fixed`);
         }
         toast.success(
           `Syllabus synchronized: ${messages.join(", ")}`,


### PR DESCRIPTION
- Complemento en IDE para el cambio realizado en CLI: [Feat/add fix generated lessons to sync syllbus dev button](https://github.com/learnpack/learnpack-cli/pull/206)
- Agrega mensaje al toast para cuando se corrigió información de lecciones ya creadas que figuraban como no generadas en el syllabus (issue [Lecciones generadas pero con status inconsistente en syllabus](https://github.com/learnpack/learnpack/issues/2053))