### PR TITLE
fix(store): merge session configuration with fresh config on session update

### DIFF
--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -2230,8 +2230,12 @@ The user's set up the application in "${language}" language, give your feedback 
         setOpenedModals({ session: true });
         return;
       } else if (session.tab_hash && session.tab_hash === storedTabHash) {
+        const freshConfig = get().configObject;
         set({
-          configObject: session.config_json,
+          configObject: {
+            ...session.config_json,
+            config: freshConfig.config,
+          },
         });
         set({ sessionKey: session.key });
 


### PR DESCRIPTION
## Resumen

Al restaurar la sesión del usuario, `configObject.config` era sobreescrito con la versión almacenada en la sesión, que podía estar desactualizada respecto al backend (ej: traducciones añadidas posteriormente). Ahora se preserva siempre el `config` fresco obtenido de la API y solo se restaura el estado de progreso del estudiante (`currentExercise`, `exercises[].done`) desde la sesión.