### PR TITLE
Fix/avoid unnecesary remounts

### DIFF
--- a/src/components/Creator/Creator.tsx
+++ b/src/components/Creator/Creator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import useStore from "../../utils/store";
+import { useShallow } from "zustand/react/shallow";
 import { useTranslation } from "react-i18next";
 import { RigoAI } from "../Rigobot/AI";
 import { Element } from "hast";
@@ -68,7 +69,7 @@ export const CreatorWrapper = ({
     token,
     configObject,
     currentExercisePosition,
-  } = useStore((state) => ({
+  } = useStore(useShallow((state) => ({
     replaceInReadme: state.replaceInReadme,
     insertBeforeOrAfter: state.insertBeforeOrAfter,
     currentContent: state.currentContent,
@@ -79,7 +80,7 @@ export const CreatorWrapper = ({
     token: state.token,
     configObject: state.configObject,
     currentExercisePosition: state.currentExercisePosition,
-  }));
+  })));
 
   const [isOpen, setIsOpen] = useState(false);
   const [replacementValue, setReplacementValue] = useState("");

--- a/src/components/Creator/RealtimeImage.tsx
+++ b/src/components/Creator/RealtimeImage.tsx
@@ -134,10 +134,9 @@ export default function RealtimeImage({
     if (data.status === "ERROR") {
       setStatus("ERROR");
       toast.error(t("imageGenerationFailed"));
-      // Keep the component visible with the error
-      // Only in creator mode does it make sense to show the generation error
       return;
     }
+    setStatus("SUCCESS");
     fetchReadme();
     reportEnrichDataLayer("creator_image_generation_completed", {
       image_id: imageId,
@@ -277,6 +276,14 @@ export default function RealtimeImage({
             </div>
           )}
         </>
+      )}
+
+      {status === "SUCCESS" && (
+        <img
+          src={`${DEV_MODE ? "http://localhost:3000" : ""}/.learn/assets/${imageId}?slug=${config?.config?.slug}`}
+          alt={innerAlt}
+          style={{ maxWidth: "100%" }}
+        />
       )}
 
       {status === "GENERATING" && (

--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import Markdown, { type Components } from "react-markdown";
 import { Element } from "hast";
 import remarkGfm from "remark-gfm";
 import { TMetadata } from "./types";
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/tooltip";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
-import { useState, useEffect, useId, useRef } from "react";
+import { useState, useEffect, useId, useRef, useMemo } from "react";
 import { DEV_MODE, asyncHashText, debounce, playEffect } from "../../../utils/lib";
 
 
@@ -155,6 +155,9 @@ const generateHeadingID = (md: string) => {
   return md.toLowerCase().replace(/ /g, "-").replace(/[^a-z0-9-]/g, "");
 }
 
+const REMARK_PLUGINS = [remarkGfm, remarkMath, emoji];
+const REHYPE_PLUGINS = [rehypeKatex];
+
 export const Markdowner = ({
   markdown,
   allowCreate = false,
@@ -188,13 +191,7 @@ export const Markdowner = ({
     }
   }, [markdown]);
 
-  return (
-    <>
-      <Markdown
-        skipHtml={true}
-        remarkPlugins={[remarkGfm, remarkMath, emoji]}
-        rehypePlugins={[rehypeKatex]}
-        components={{
+  const components = useMemo((): Partial<Components> => ({
           a: ({ href, children }) => {
             if (href) {
               if (isRigoQuestion(href)) {
@@ -509,7 +506,15 @@ export const Markdowner = ({
               />
             );
           },
-        }}
+  }), [openLink, mode, isCreator, config, getPortion, allowCreate, markdown]);
+
+  return (
+    <>
+      <Markdown
+        skipHtml={true}
+        remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={REHYPE_PLUGINS}
+        components={components}
       >
         {markdown}
       </Markdown>

--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -506,7 +506,7 @@ export const Markdowner = ({
               />
             );
           },
-  }), [openLink, mode, isCreator, config, getPortion, allowCreate, markdown]);
+  }), [openLink, mode, isCreator, config, getPortion, allowCreate, markdown, creatorModeActivated]);
 
   return (
     <>

--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -5,6 +5,7 @@ import { TMetadata } from "./types";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import useStore from "../../../utils/store";
+import { useShallow } from "zustand/react/shallow";
 import emoji from "remark-emoji";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark as prismStyle } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -165,13 +166,13 @@ export const Markdowner = ({
   markdown: string;
   allowCreate?: boolean;
 }) => {
-  const { openLink, mode, isCreator, config, getPortion } = useStore((state) => ({
+  const { openLink, mode, isCreator, config, getPortion } = useStore(useShallow((state) => ({
     openLink: state.openLink,
     mode: state.mode,
     isCreator: state.isCreator,
     config: state.configObject,
     getPortion: state.getPortion,
-  }));
+  })));
 
   const creatorModeActivated = isCreator && mode === "creator" && allowCreate;
 


### PR DESCRIPTION
## Resumen

- Corrección de remounts innecesarios en `react-markdown` que provocaban pérdida de estado en componentes custom del
  `Markdowner`
- fix del estado GENERATING que quedaba congelado tras una generación de imagen exitosa (luego de los cambios del punto anterior)

  ## Cambios principales

  - **`Markdowner`**: se memoiza el objeto `components`   ([ref](https://github.com/remarkjs/react-markdown/issues/849))
  - se aplica  `useShallow` al selector de Zustand para evitar re-renders ante cualquier `set()` del store
  - **`CreatorWrapper`**: ídem con `useShallow` para el selector de Zustand
  - **`RealtimeImage`**: en `handleUpdate`, al recibir SUCCESS se llama a `setStatus("SUCCESS")` y se renderiza la
  imagen directamente, sin depender del remount de `CustomImage`

  ## Justificación técnica

  Los selectores de objeto en Zustand sin `useShallow` retornan siempre una nueva referencia, provocando que
  `react-markdown` desmonte y remonte todos los componentes custom ante cualquier cambio de estado global. Esto causaba
  pérdida del estado local de propuestas generadas por el backend en usuarios con `ai_generation > 1`. Adicionalmente,
  `fetchReadme()` no modifica el prefijo `GENERATING` en el README, por lo que el componente quedaba congelado sin poder
   transicionar a SUCCESS por cuenta propia.