### PR TITLE
fix(telemetry): completar steps inmediatamente y actualizar UI de forma reactiva

### DIFF
--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -18,15 +18,14 @@ const ContinueButton = () => {
   const agent = useStore((s) => s.agent);
   const exercises = useStore((s) => s.exercises);
   const [loading, setLoading] = useState(false);
+  const [, setCompletionTick] = useState(0);
   const isLastExercise = currentExercisePosition === exercises.length - 1;
 
-  // Check if the current step still has pending tasks (tests/quizzes not completed)
   const hasPendingTasks =
     typeof currentExercisePosition === "number" || typeof currentExercisePosition === "string"
       ? TelemetryManager.hasPendingTasks(Number(currentExercisePosition))
       : false;
 
-  // Check if there are pending tasks in any lesson
   const hasPendingTasksInAnyLesson = TelemetryManager.hasPendingTasksInAnyLesson();
 
   const isFinishDisabled = isLastExercise && (hasPendingTasks || hasPendingTasksInAnyLesson);
@@ -42,17 +41,23 @@ const ContinueButton = () => {
     const handlePositionChanged = () => {
       setLoading(false);
     };
-    
+
     const handleLastLessonFinished = () => {
       setLoading(false);
     };
 
+    const handleStepCompleted = () => {
+      setCompletionTick((t) => t + 1);
+    };
+
     eventBus.on("position_changed", handlePositionChanged);
     eventBus.on("last_lesson_finished", handleLastLessonFinished);
+    eventBus.on("step_completed", handleStepCompleted);
 
     return () => {
       eventBus.off("position_changed", handlePositionChanged);
       eventBus.off("last_lesson_finished", handleLastLessonFinished);
+      eventBus.off("step_completed", handleStepCompleted);
     };
   }, []);
 

--- a/src/components/sections/sidebar/ExercisesList.tsx
+++ b/src/components/sections/sidebar/ExercisesList.tsx
@@ -428,7 +428,16 @@ function ExerciseCard({
   const current = getCurrentExercise();
   const isCurrent = current.slug === slug;
 
-  const isDone = TelemetryManager.isStepCompleted(position);
+  const [isDone, setIsDone] = useState(() => TelemetryManager.isStepCompleted(position));
+
+  useEffect(() => {
+    const handler = (completedPosition: number) => {
+      if (completedPosition === position) setIsDone(true);
+    };
+    eventBus.on("step_completed", handler);
+    return () => eventBus.off("step_completed", handler);
+  }, [position]);
+
   const isTesteableAndDone = isDone && TelemetryManager.isTesteable(position);
 
 

--- a/src/managers/eventBus.ts
+++ b/src/managers/eventBus.ts
@@ -12,6 +12,7 @@ type Events = {
   };
   last_lesson_finished: {};
   lesson_rendered: { stepPosition: number };
+  step_completed: number;
 };
 
 export const eventBus: Emitter<Events> = mitt<Events>();

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1280,8 +1280,6 @@ const TelemetryManager: ITelemetryManager = {
    * the user navigated to another step), so stale completions are avoided.
    */
   onLessonRendered: function (stepPosition: number) {
-    if (!this.current) return;
-
     // Cancel any pending debounce from a previous step/render.
     if (this._lessonRenderedDebounce) {
       this._lessonRenderedDebounce.cancel();

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1266,6 +1266,7 @@ const TelemetryManager: ITelemetryManager = {
     step.is_completed = true;
     this.current.steps[stepPosition] = step;
     this.save();
+    eventBus.emit("step_completed", stepPosition);
   },
 
   /**
@@ -1388,6 +1389,7 @@ const TelemetryManager: ITelemetryManager = {
         if (!hasPendingTasks && !step.completed_at && data.exit_code === 0) {
           step.completed_at = now;
           step.is_completed = true;
+          eventBus.emit("step_completed", stepPosition);
         }
 
         this.current.steps[stepPosition] = step;
@@ -1408,16 +1410,23 @@ const TelemetryManager: ITelemetryManager = {
 
         step.quiz_submissions.push(data);
 
+        const isSuccessfulSubmission = data?.status === "SUCCESS";
+
+        // registerTesteableElement (which marks the element is_completed) always
+        // runs after registerStepEvent, so hasPendingTasks would see the current
+        // element as still incomplete. Pre-update it here so the check is accurate.
+        if (isSuccessfulSubmission && step.testeable_elements) {
+          step.testeable_elements = step.testeable_elements.map((e) =>
+            e.hash === data.quiz_hash ? { ...e, is_completed: true } : e
+          );
+        }
+
         const now = Date.now();
         const hasPendingTasks = this.hasPendingTasks(stepPosition);
-        const isSuccessfulSubmission = data?.status === "SUCCESS";
-        if (
-          isSuccessfulSubmission &&
-          !hasPendingTasks &&
-          !step.completed_at
-        ) {
+        if (isSuccessfulSubmission && !hasPendingTasks && !step.completed_at) {
           step.completed_at = now;
           step.is_completed = true;
+          eventBus.emit("step_completed", stepPosition);
         }
 
         this.current.steps[stepPosition] = step;
@@ -1464,6 +1473,7 @@ const TelemetryManager: ITelemetryManager = {
             prev.is_completed = true;
             prev.completed_at = now;
             this.current.steps[this.prevStep] = prev;
+            eventBus.emit("step_completed", this.prevStep);
           }
         }
 


### PR DESCRIPTION
## Problemas
  - El botón Finish no se activaba al completar el último step pendiente estando en la última lección; había que navegar
   y volver.
  - Las cards del sidebar no se marcaban como completadas en tiempo real.
  - La primera lección (solo lectura) no se completaba al elegir "comenzar de nuevo" en el modal inicial; había que
  navegar y volver.

 ## Causas
  - En `quiz_submission`, `hasPendingTasks` se evaluaba antes de que el elemento del quiz se marcara como completado,
  leyendo estado viejo y nunca cerrando el step al momento del submit.
  - `ContinueButton` y `ExerciseCard` leían el estado de telemetría sin suscribirse a cambios, por lo que no se
  re-renderizaban.
  - Un `return` temprano en `onLessonRendered` cortaba la ejecución cuando `this.current` era `null`, que es el estado
  inicial al cargar la app con "comenzar de nuevo".

 ## Solución
  - Se pre-actualiza `testeable_elements` antes de llamar `hasPendingTasks` en el caso `quiz_submission`.
  - Se emite el nuevo evento `step_completed` en todos los paths que asignan `completed_at`; `ContinueButton` y
  `ExerciseCard` se suscriben para re-renderizarse sin navegación.
  - Se elimina el `return` temprano en `onLessonRendered`.