### PR TITLE
fix: align fill-in-the-blank UI validation with submission logic

### DIFF
--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -13,6 +13,7 @@ import { QuizRenderer } from "../QuizRenderer/QuizRenderer";
 import {
   buildFillInTheBlankIdentityString,
   getLatestQuizSubmission,
+  isFillInTheBlankAnswerCorrect,
   makeFillInTheBlankSubmission,
 } from "../QuizRenderer/quizSubmissionUtils";
 import { RigoQuestion } from "../RigoQuestion/RigoQuestion";
@@ -1183,8 +1184,13 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
       }
 
       const blankNum = match[1];
-      const isCorrect = submitted && correctAnswers[blankNum]?.includes(answers[blankNum]?.toLowerCase());
-      const isIncorrect = submitted && answers[blankNum] && !correctAnswers[blankNum]?.includes(answers[blankNum]?.toLowerCase());
+      const isCorrect =
+        submitted &&
+        isFillInTheBlankAnswerCorrect(answers[blankNum], correctAnswers[blankNum]);
+      const isIncorrect =
+        submitted &&
+        answers[blankNum]?.trim() &&
+        !isFillInTheBlankAnswerCorrect(answers[blankNum], correctAnswers[blankNum]);
 
       let inputClassName = "fill-blank-input";
       if (submitted) {
@@ -1229,8 +1235,8 @@ const FillInTheBlankRenderer = ({ code, metadata }: { code: string, node: any, m
   const allFilled = uniqueBlanks.every(blankNum => answers[blankNum]?.trim());
 
   // Calculate score
-  const correctCount = uniqueBlanks.filter(blankNum =>
-    correctAnswers[blankNum]?.includes(answers[blankNum]?.toLowerCase())
+  const correctCount = uniqueBlanks.filter((blankNum) =>
+    isFillInTheBlankAnswerCorrect(answers[blankNum], correctAnswers[blankNum])
   ).length;
   const totalCount = uniqueBlanks.length;
 

--- a/src/components/composites/QuizRenderer/quizSubmissionUtils.ts
+++ b/src/components/composites/QuizRenderer/quizSubmissionUtils.ts
@@ -92,6 +92,19 @@ export const buildFillInTheBlankIdentityString = (
   return `fitb:${code.trim()}:${metaPart}`;
 };
 
+/** Normalizes user input for fill-in-the-blank comparison (trim + lowercase). */
+export const normalizeFillInTheBlankAnswer = (answer: string): string =>
+  (answer ?? "").trim().toLowerCase();
+
+export const isFillInTheBlankAnswerCorrect = (
+  userAnswer: string | undefined,
+  correctOptions: string[] | undefined
+): boolean => {
+  const normalized = normalizeFillInTheBlankAnswer(userAnswer ?? "");
+  if (!normalized) return false;
+  return Boolean(correctOptions?.includes(normalized));
+};
+
 export const makeFillInTheBlankSubmission = (
   uniqueBlanks: string[],
   answers: Record<string, string>,
@@ -101,8 +114,10 @@ export const makeFillInTheBlankSubmission = (
 ): TQuizSubmission => {
   const selections = uniqueBlanks.map((blankNum) => {
     const raw = (answers[blankNum] ?? "").trim();
-    const userLower = raw.toLowerCase();
-    const isCorrect = Boolean(correctAnswers[blankNum]?.includes(userLower));
+    const isCorrect = isFillInTheBlankAnswerCorrect(
+      answers[blankNum],
+      correctAnswers[blankNum]
+    );
     return {
       question: `blank_${blankNum}`,
       answer: raw,


### PR DESCRIPTION
## Resumen
Corrige el comportamiento en el que respuestas correctas con espacios al inicio o al final mostraban confetti y toast de éxito, pero el input se marcaba en rojo y la puntuación no reflejaba el acierto.

## Cambios
- Se centraliza la comparación en `isFillInTheBlankAnswerCorrect` (`quizSubmissionUtils.ts`) con `trim` + `toLowerCase`.
- El marcado visual de inputs y el contador de resultados en `FillInTheBlankRenderer` usan la misma lógica que el envío a telemetría.

## Impacto
Feedback visual, puntuación y completado del paso quedan alineados cuando el texto es correcto pero incluye espacios extra.