### PR TITLE
Feat: gestionar errores de Rigobot al ejecutar Run/Test

### DIFF
--- a/src/components/Rigobot/AI.tsx
+++ b/src/components/Rigobot/AI.tsx
@@ -111,6 +111,15 @@ export const RigoTemplate = {
         }
       },
       run: async () => {
+        // TEMP LOCAL: simulate Rigobot 503 to test error UX.
+        // const SIMULATE_503 = true;
+        // if (SIMULATE_503) {
+        //   onComplete?.(false, {
+        //     error: "Simulated 503 Service Unavailable",
+        //     status: 503,
+        //   });
+        //   return;
+        // }
         try {
           const { default: Pusher } = await import("pusher-js");
           pusherClient = new Pusher(resolvedSoketiKey, {
@@ -139,7 +148,8 @@ export const RigoTemplate = {
             console.log("Error using template errorData", errorData);
             onComplete?.(false, {
               error: errorData.detail || `HTTP error! status: ${response.status}`,
-          });
+              status: response.status,
+            });
             return;
           }
           const data = await response.json();

--- a/src/components/composites/SocketHandler.tsx
+++ b/src/components/composites/SocketHandler.tsx
@@ -19,6 +19,7 @@ export function SocketHandler() {
     build,
     runExerciseTests,
     setUser,
+    clearCompilationWatchdog,
   } = useStore((state) => ({
     compilerSocket: state.compilerSocket,
     exercises: state.exercises,
@@ -31,6 +32,7 @@ export function SocketHandler() {
     build: state.build,
     runExerciseTests: state.runExerciseTests,
     setUser: state.setUser,
+    clearCompilationWatchdog: state.clearCompilationWatchdog,
   }));
 
   const [inputsResponses, setInputsResponses] = useState([] as string[]);
@@ -81,6 +83,7 @@ export function SocketHandler() {
     });
 
     compilerSocket.on("ask", async ({ inputs, nextAction }: any) => {
+      clearCompilationWatchdog();
       setInputs(inputs);
       if (nextAction) {
         setNextAction(nextAction);

--- a/src/components/sections/header/CompileOptions.tsx
+++ b/src/components/sections/header/CompileOptions.tsx
@@ -21,20 +21,26 @@ export const CompileOptions = ({
   isHtml?: boolean;
 }) => {
   const { t } = useTranslation();
-  const { isBuildable, isTesteable, isCompiling } = useStore((state) => ({
+  const { isBuildable, isTesteable, isCompiling, lastState, serviceError } = useStore((state) => ({
     isBuildable: state.isBuildable,
     isTesteable: state.isTesteable,
     isCompiling: state.isCompiling,
+    lastState: state.lastState,
+    serviceError: state.serviceError,
   }));
+
+  const hasError = !isCompiling && !isRunning && lastState === "error";
+  const errorIcon = serviceError ? svgs.warning : svgs.testIcon;
+  const errorText = serviceError ? t("retry") : t("try-again");
 
   return (
     <Dropdown
       className={dropdownDirection}
       openingElement={
         <SimpleButton
-          extraClass={`compiler rounded padding-small ${isCompiling ? "palpitate" : ""}`}
-          svg={svgs.run}
-          text={isCompiling || isRunning ? t("Running...") : t("Run")}
+          extraClass={`compiler rounded padding-small ${isCompiling ? "palpitate" : ""} ${hasError ? "bg-fail text-white" : ""}`}
+          svg={hasError ? errorIcon : svgs.run}
+          text={isCompiling || isRunning ? t("Running...") : hasError ? errorText : t("Run")}
         />
       }
     >

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -448,6 +448,7 @@
     "imageUploadedSuccessfully": "Image uploaded successfully",
     "theCourseIsNotSaved": "The course is not saved",
     "retry": "Retry",
+    "Retrying...": "Retrying...",
     "lesson-generation-started": "Lesson generation started",
     "give-feedback-on-the-course-so-far": "Give feedback on the course so far",
     "give-feedback-to-rigobot": "Give feedback to Rigobot, explain what you want to change or what you like about the course so far",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -456,6 +456,7 @@
     "imageUploadedSuccessfully": "Imagen subida exitosamente",
     "theCourseIsNotSaved": "El curso no está guardado",
     "retry": "Reintentar",
+    "Retrying...": "Reintentando...",
     "lesson-generation-started": "La lección está siendo generada",
     "give-feedback-on-the-course-so-far": "Dale tu opinión sobre el curso hasta ahora",
     "give-feedback-to-rigobot": "Dale tu opinión a Rigobot, explica lo que quieres cambiar o lo que te gusta del curso hasta ahora",

--- a/src/managers/EventProxy.ts
+++ b/src/managers/EventProxy.ts
@@ -139,6 +139,64 @@ function expandRepeatTags(text: string): string {
   });
 }
 
+const RETRYABLE_STATUSES = [502, 503, 504];
+const MAX_RETRIES = 2;
+const BACKOFF_MS = [1000, 2000];
+
+function runTemplateWithRetry(
+  {
+    slug,
+    inputs,
+    target,
+    targetButton,
+  }: {
+    slug: string;
+    inputs: Record<string, string>;
+    target?: HTMLElement;
+    targetButton: "feedback" | "build";
+  },
+  onSuccess: (json: any) => void,
+  attempt = 0
+) {
+  RigoAI.useTemplate({
+    slug,
+    inputs,
+    target,
+    onComplete: (success, rigoData) => {
+      const parsed = rigoData?.data?.parsed;
+      if (success && parsed) {
+        onSuccess(parsed);
+        return;
+      }
+
+      const status = rigoData?.status ?? rigoData?.error?.status;
+      const isRetryable =
+        status === undefined || RETRYABLE_STATUSES.includes(status);
+      if (isRetryable && attempt < MAX_RETRIES) {
+        localStorageEventEmitter.emitStatus("retrying", {
+          targetButton,
+          attempt: attempt + 1,
+        });
+        setTimeout(
+          () =>
+            runTemplateWithRetry(
+              { slug, inputs, target, targetButton },
+              onSuccess,
+              attempt + 1
+            ),
+          BACKOFF_MS[attempt]
+        );
+        return;
+      }
+      localStorageEventEmitter.emitStatus("service-error", {
+        targetButton,
+        error: rigoData?.error,
+        status,
+      });
+    },
+  });
+}
+
 localStorageEventEmitter.on("build", async (data) => {
   try {
     const cachedEditorTabs =
@@ -247,14 +305,15 @@ localStorageEventEmitter.on("build", async (data) => {
       inputs: JSON.stringify(inputsObject),
     };
     
-    RigoAI.useTemplate({
-      slug: "structured-build-learnpack",
-      inputs,
-      // target: ,
-      onComplete: (success, rigoData) => {
-        console.log("RIGOBOT AI COMPLETE the build", success, rigoData);
+    runTemplateWithRetry(
+      {
+        slug: "structured-build-learnpack",
+        inputs,
+        targetButton: "build",
+      },
+      (json) => {
+        console.log("RIGOBOT AI COMPLETE the build", json);
 
-        const json = rigoData.data.parsed;
         json.ai_required = true;
         json.started_at = started_at;
         const ended_at = new Date().getTime();
@@ -272,7 +331,6 @@ localStorageEventEmitter.on("build", async (data) => {
         }
 
         if (logs !== null) {
-          // toast.success("RIGOBOT AI SUCCESS IN THE BUILD EVENT");
           let terminalContent = ``;
           logs.forEach((log: any) => {
             terminalContent += `\`\`\`stdout\n${log.stdout}\n\`\`\`\n`;
@@ -293,8 +351,8 @@ localStorageEventEmitter.on("build", async (data) => {
 
           data.updateEditorTabs(terminalTab);
         }
-      },
-    });
+      }
+    );
   } catch (error) {
     if (error instanceof TokenExpired) {
       console.warn("Token expired. Logging out...");
@@ -306,6 +364,9 @@ localStorageEventEmitter.on("build", async (data) => {
         "Something unexpected happened in the build event": error,
       });
       toast.error("Something unexpected happened in the build event");
+      localStorageEventEmitter.emitStatus("service-error", {
+        targetButton: "build",
+      });
       reportDataLayer({
         dataLayer: {
           event: "learnpack_unexpected_error",
@@ -416,15 +477,16 @@ localStorageEventEmitter.on("test", async (data) => {
     // console.log(inputs, "INPUTS SENT TO RIGOBOT");
 
     const starting_at = new Date().getTime();
-    RigoAI.useTemplate({
-      slug: "test-instructions-learnpack",
-      inputs,
-      onComplete: (success, rigoData) => {
-        console.log("RIGOBOT AI COMPLETE the test", success, rigoData);
-        const json = rigoData.data.parsed;
+    runTemplateWithRetry(
+      {
+        slug: "test-instructions-learnpack",
+        inputs,
+        targetButton: "feedback",
+      },
+      (json) => {
+        console.log("RIGOBOT AI COMPLETE the test", json);
         const ended_at = new Date().getTime();
         json.ended_at = ended_at;
-        // const json = extractAndParseResult(dataRigobotReturns);
         json.source_code = JSON.stringify(inputs);
         json.started_at = starting_at;
 
@@ -467,8 +529,8 @@ localStorageEventEmitter.on("test", async (data) => {
             logs: [JSON.stringify(json)],
           });
         }
-      },
-    });
+      }
+    );
   } catch (error) {
     if (error instanceof TokenExpired) {
       console.warn("Token expired. Logging out...");
@@ -477,7 +539,9 @@ localStorageEventEmitter.on("test", async (data) => {
       await FetchManager.logout();
     } else {
       console.log(error);
-
+      localStorageEventEmitter.emitStatus("service-error", {
+        targetButton: "feedback",
+      });
       return;
     }
   }

--- a/src/managers/socket.ts
+++ b/src/managers/socket.ts
@@ -16,6 +16,7 @@ const messages = {
     testingError: "Check the terminal for more detailed info.",
     testingSuccess: "Everything as expected.",
     internalError: "Woops! There has been an internal error",
+    serviceError: "The evaluation service is unavailable. Please try again in a few seconds.",
     prettifying: "Making code prettier",
     prettifySuccess: "Look how beautiful your code is now",
     completed: "Excellent!",
@@ -61,6 +62,7 @@ const messages = {
     testingError: "Check the terminal for more detailed info.",
     testingSuccess: "Everything as expected.",
     internalError: "Woops! There has been an internal error",
+    serviceError: "The evaluation service is unavailable. Please try again in a few seconds.",
     prettifying: "Making code prettier",
     prettifySuccess: "Look how beautiful your code is now",
     completed: "Excellent!",
@@ -106,6 +108,7 @@ const messages = {
     testingError: "Consulta la terminal para más información detallada.",
     testingSuccess: "Todo como se esperaba.",
     internalError: "¡Ups! Ha habido un error interno",
+    serviceError: "El servicio de evaluacion no esta disponible. Intentalo de nuevo en unos segundos.",
     prettifying: "Haciendo el código más bonito",
     prettifySuccess: "Mira qué bonito está tu código ahora",
     completed: "¡Excelente!",
@@ -207,6 +210,8 @@ export const getStatus = function (status = "initializing", language = "en") {
       return [getGoodIcon(), messages[language].testingSuccess];
     case "internal-error":
       return ["🔥💻", messages[language].internalError];
+    case "service-error":
+      return ["🛜", messages[language].serviceError];
     case "prettifying":
       return ["✨", messages[language].prettifying];
     case "prettify-success":

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -332,6 +332,8 @@ const useStore = create<IStore>((set, get) => ({
     aiMessage: "",
   },
   isCompiling: false,
+  compilationWatchdog: null as ReturnType<typeof setTimeout> | null,
+  serviceError: false,
   showSidebar: false,
   user_id: null,
   hasSolution: false,
@@ -535,10 +537,11 @@ const useStore = create<IStore>((set, get) => ({
     } = get();
 
     const debounceTestingSuccess = debounce((data: any) => {
+      get().clearCompilationWatchdog();
       const stdout = removeSpecialCharacters(data.logs[0]);
 
       setTestResult("successful", stdout);
-      set({ isCompiling: false });
+      set({ isCompiling: false, serviceError: false });
       set({ lastState: "success", terminalShouldShow: true });
       toastFromStatus("testing-success");
       eventBus.emit("assessment_completed", {
@@ -576,8 +579,9 @@ const useStore = create<IStore>((set, get) => ({
     }, 100);
 
     const debounceTestingError = debounce((data: any) => {
+      get().clearCompilationWatchdog();
       const stdout = removeSpecialCharacters(data.logs[0]);
-      set({ isCompiling: false });
+      set({ isCompiling: false, serviceError: false });
       setTestResult("failed", stdout);
       set({ lastState: "error", terminalShouldShow: true });
       toastFromStatus("testing-error");
@@ -617,9 +621,10 @@ const useStore = create<IStore>((set, get) => ({
 
     let compilerErrorHandler = debounce(async (data: any) => {
       data;
+      get().clearCompilationWatchdog();
 
       set({ lastState: "error", terminalShouldShow: true });
-      set({ isCompiling: false });
+      set({ isCompiling: false, serviceError: false });
 
       setBuildButtonPrompt("try-again", "bg-fail text-white");
 
@@ -635,8 +640,9 @@ const useStore = create<IStore>((set, get) => ({
 
     let compilerSuccessHandler = debounce(async (data: any) => {
       data;
+      get().clearCompilationWatchdog();
       set({ lastState: "success", terminalShouldShow: true });
-      set({ isCompiling: false });
+      set({ isCompiling: false, serviceError: false });
 
       toastFromStatus("compiler-success");
 
@@ -658,6 +664,19 @@ const useStore = create<IStore>((set, get) => ({
     compilerSocket.onStatus("testing-error", debounceTestingError);
     compilerSocket.onStatus("compiler-error", compilerErrorHandler);
     compilerSocket.onStatus("compiler-success", compilerSuccessHandler);
+
+    compilerSocket.onStatus("service-error", () => {
+      get().failCompilation();
+    });
+
+    compilerSocket.onStatus("retrying", (data: any) => {
+      const text = "Retrying...";
+      if (data?.targetButton === "feedback") {
+        setFeedbackButtonProps(text, "palpitate");
+      } else {
+        setBuildButtonPrompt(text, "palpitate");
+      }
+    });
 
     compilerSocket.onStatus("open_window", () => {
       toastFromStatus("open_window");
@@ -717,6 +736,39 @@ const useStore = create<IStore>((set, get) => ({
 
   setFeedbackButtonProps: (t, c = "") => {
     set({ feedbackbuttonProps: { text: t, className: c } });
+  },
+
+  startCompilationWatchdog: () => {
+    get().clearCompilationWatchdog();
+    const id = setTimeout(() => {
+      if (get().isCompiling) get().failCompilation();
+    }, 60000);
+    set({ compilationWatchdog: id });
+  },
+
+  clearCompilationWatchdog: () => {
+    const { compilationWatchdog } = get();
+    if (compilationWatchdog) clearTimeout(compilationWatchdog);
+    set({ compilationWatchdog: null });
+  },
+
+  failCompilation: () => {
+    const {
+      setFeedbackButtonProps,
+      setBuildButtonPrompt,
+      language,
+      targetButtonForFeedback,
+      clearCompilationWatchdog,
+    } = get();
+    clearCompilationWatchdog();
+    set({ isCompiling: false, lastState: "error", serviceError: true });
+    if (targetButtonForFeedback === "feedback") {
+      setFeedbackButtonProps("retry", "bg-fail text-white");
+    } else {
+      setBuildButtonPrompt("retry", "bg-fail text-white");
+    }
+    const [icon, message] = getStatus("service-error", language);
+    toast.error(message, { icon, duration: 6000 });
   },
 
   setOpenedModals: (modals) => {
@@ -2091,6 +2143,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
     setBuildButtonPrompt(buildText, "");
     toastFromStatus("compiling");
+    set({ targetButtonForFeedback: "build" });
 
     const data = {
       exerciseSlug: getCurrentExercise().slug,
@@ -2104,6 +2157,7 @@ The user's set up the application in "${language}" language, give your feedback 
     set({ lastStartedAt: new Date() });
     reportEnrichDataLayer("learnpack_run", {});
     set({ isCompiling: true });
+    get().startCompilationWatchdog();
   },
   setEditorTabs: (tabs) => {
     set({ editorTabs: tabs });
@@ -2179,6 +2233,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
     if (opts && opts.toast) toastFromStatus("testing");
     set({ isCompiling: true });
+    get().startCompilationWatchdog();
   },
 
   getOrCreateActiveSession: async () => {
@@ -3059,7 +3114,7 @@ The user's set up the application in "${language}" language, give your feedback 
     );
     const ai_generation = countConsumables(consumables, "ai-generation");
 
-    //const ai_generation = 0;
+    //const ai_generation = -1;
 
     set({
       userConsumables: {

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -347,6 +347,9 @@ export interface IStore {
   terminalShouldShow: boolean;
   rigoContext: TRigoContext;
   isCompiling: boolean;
+  compilationWatchdog: ReturnType<typeof setTimeout> | null;
+  /** True only when the last run failed due to a service/infrastructure error (e.g. Rigobot 503), not the student's code. */
+  serviceError: boolean;
   showSidebar: boolean;
   userConsumables: TUserConsumables;
   maxQuizRetries: number;
@@ -402,6 +405,9 @@ export interface IStore {
   setToken: (newToken: string) => void;
   setBuildButtonPrompt: (t: string, c: string) => void;
   setFeedbackButtonProps: (t: string, c: string) => void;
+  startCompilationWatchdog: () => void;
+  clearCompilationWatchdog: () => void;
+  failCompilation: () => void;
   fetchSingleExerciseInfo: (index: number) => Promise<TExercise>;
   toggleFeedback: () => void;
   fetchExercises: () => Promise<boolean | void>;


### PR DESCRIPTION
## Problema que resuelve
Cuando Rigobot devolvía un error (p. ej. 503) o no respondía, el IDE no reaccionaba: el botón quedaba atascado en "Running..." indefinidamente y el alumno debía recargar la pestaña, generando una pésima UX.

## Solución
- Se maneja el fallo en los callbacks de `test`/`build`: si Rigobot no responde con datos válidos, se reintenta hasta 2 veces (backoff 1s/2s) ante 502/503/504 y, si persiste, se emite un estado de error de servicio.
- Se añade un *watchdog* de 60s que desbloquea el botón aunque nunca llegue respuesta.
- Se distingue visualmente el error de servicio (icono de alerta, "Reintentar") del error del propio código del alumno (icono de tests, "Intenta de nuevo"), reflejándolo también en el botón principal "Run" para que sea visible aunque el menú se cierre.
- Se muestra un toast informativo (6s) y se permite reintentar sin recargar.