### PR TITLE
Fix: evitar que la evaluación de open questions quede colgada ante fallos de Rigobot

### DIFF
--- a/src/components/Rigobot/AI.tsx
+++ b/src/components/Rigobot/AI.tsx
@@ -302,7 +302,7 @@ export const RigoAI = {
     inputs: Record<string, string>;
     target?: HTMLElement;
     onComplete?: (success: boolean, data: any) => void;
-  }) => {
+  }): TAgentJob | undefined => {
     // @ts-ignore
     if (!window.rigo) {
       console.error("RIGOBOT AI NOT LOADED");
@@ -329,7 +329,9 @@ export const RigoAI = {
 
     if (job) {
       job.run();
+      return job;
     }
+    return undefined;
   },
 
   ask: (

--- a/src/components/composites/OpenQuestion/OpenQuestion.tsx
+++ b/src/components/composites/OpenQuestion/OpenQuestion.tsx
@@ -17,10 +17,11 @@ import { AutoResizeTextarea } from "../AutoResizeTextarea/AutoResizeTextarea";
 import { Markdowner } from "../Markdowner/Markdowner";
 import TelemetryManager, { TTesteableElement } from "../../../managers/telemetry";
 import { makeQuizSubmission } from "../QuizRenderer/quizSubmissionUtils";
-import { RigoAI } from "../../Rigobot/AI";
+import { RigoAI, TAgentJob } from "../../Rigobot/AI";
 import CustomDropdown from "../../CustomDropdown";
 import { Icon } from "../../Icon"
 import { eventBus } from "@/managers/eventBus";
+import { getStatus } from "../../../managers/socket";
 const splitInLines = (code: string) => {
   return code.split("\n").filter((line) => line.trim() !== "");
 };
@@ -29,6 +30,10 @@ type TFeedback = {
   exit_code: number;
   feedback: string;
 };
+
+// If Rigobot doesn't respond within this window (e.g. H12 timeout where the
+// completion webhook never arrives), we stop waiting and offer a retry.
+const EVALUATION_TIMEOUT_MS = 60000;
 
 export const Question = ({
   metadata,
@@ -72,6 +77,9 @@ export const Question = ({
 
   const [feedback, setFeedback] = useState<TFeedback | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  // Infrastructure/service failure (Rigobot error or timeout), distinct from a
+  // legitimate "your answer needs improvement" result.
+  const [serviceError, setServiceError] = useState<boolean>(false);
   const [examples, setExamples] = useState<string[]>(splitInLines(code));
   const [answer, setAnswer] = useState("");
   const [questionHash, setQuestionHash] = useState<string>("");
@@ -79,6 +87,11 @@ export const Question = ({
   const hashRef = useRef<string>("");
   const startedAtRef = useRef<number>(0);
   const isRestoredFeedbackRef = useRef(false);
+  const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const jobRef = useRef<TAgentJob | undefined>(undefined);
+  // Ensures only the first outcome (success / server error / timeout) wins, so a
+  // webhook arriving after the timeout can't reprocess a settled evaluation.
+  const settledRef = useRef(false);
 
   // Generate hash immediately when component mounts or metadata.eval changes
   useEffect(() => {
@@ -184,6 +197,32 @@ export const Question = ({
 
 
 
+  const clearWatchdog = () => {
+    if (watchdogRef.current) {
+      clearTimeout(watchdogRef.current);
+      watchdogRef.current = null;
+    }
+  };
+
+  // Bail out of the loading state when the evaluation can't complete because of a
+  // service problem: either Rigobot returned an error (server) or no response
+  // arrived in time (timeout). Does NOT register a quiz_submission, so it never
+  // counts as a failed student attempt.
+  const handleEvaluationFailure = (reason: "timeout" | "server") => {
+    if (settledRef.current) return;
+    settledRef.current = true;
+
+    clearWatchdog();
+    jobRef.current?.stop();
+    setIsLoading(false);
+    setServiceError(true);
+
+    const [icon, message] = getStatus("service-error", language);
+    toast.error(message, { icon, duration: 6000 });
+
+    reportEnrichDataLayer("open_question_evaluation_error", { reason });
+  };
+
   const evaluateAnswer = async () => {
     if (!answer) {
       toast.error(t("pleaseEnterAnAnswer"));
@@ -194,8 +233,18 @@ export const Question = ({
       setOpenedModals({ mustLogin: true });
       return;
     }
+    settledRef.current = false;
+    setServiceError(false);
+    setFeedback(null);
     setIsLoading(true);
-    RigoAI.useTemplate({
+
+    clearWatchdog();
+    watchdogRef.current = setTimeout(
+      () => handleEvaluationFailure("timeout"),
+      EVALUATION_TIMEOUT_MS
+    );
+
+    jobRef.current = RigoAI.useTemplate({
       slug: "evaluator",
       inputs: {
         eval: metadata.eval as string,
@@ -204,7 +253,11 @@ export const Question = ({
         examples: examples.join("\n"),
       },
       onComplete: (success, rigoData) => {
+        if (settledRef.current) return;
+
         if (success) {
+          settledRef.current = true;
+          clearWatchdog();
           const result = rigoData.data.parsed;
           setFeedback({
             exit_code: result.exit_code,
@@ -260,10 +313,20 @@ export const Question = ({
 
           setIsLoading(false);
           useConsumable("ai-compilation");
+        } else {
+          handleEvaluationFailure("server");
         }
       },
     });
   };
+
+  // Tear down any in-flight evaluation (watchdog + Pusher subscription) on unmount.
+  useEffect(() => {
+    return () => {
+      clearWatchdog();
+      jobRef.current?.stop();
+    };
+  }, []);
 
   const handleTranscription = (text: string) => {
     // Clear feedback when user adds transcription
@@ -304,6 +367,10 @@ ${newExamples.join("\n")}
             if (feedback) {
               setFeedback(null);
             }
+            // Clear any previous service error once the user edits the answer
+            if (serviceError) {
+              setServiceError(false);
+            }
             setAnswer(e.target.value);
           }}
         />
@@ -312,11 +379,25 @@ ${newExamples.join("\n")}
       <div className="d-flex gap-small padding-small justify-between row-reverse">
         <SimpleButton
           disabled={isLoading || !answer}
-          text={isLoading ? t("evaluating") : t("submitForReview")}
-          title={isLoading ? t("evaluating") : t("submitForReview")}
-          svg={svgs.rigoSoftBlue}
+          text={
+            isLoading
+              ? t("evaluating")
+              : serviceError
+              ? t("retry")
+              : t("submitForReview")
+          }
+          title={
+            isLoading
+              ? t("evaluating")
+              : serviceError
+              ? t("retry")
+              : t("submitForReview")
+          }
+          svg={serviceError ? svgs.warning : svgs.rigoSoftBlue}
           action={evaluateAnswer}
-          extraClass="active-on-hover padding-small rounded align-self-end bg-blue-rigo text-white"
+          extraClass={`active-on-hover padding-small rounded align-self-end text-white ${
+            serviceError ? "bg-fail" : "bg-blue-rigo"
+          }`}
         />
         {isCreator && mode === "creator" && (
           <AddExampleButton
@@ -327,6 +408,11 @@ ${newExamples.join("\n")}
           />
         )}
       </div>
+      {serviceError && !isLoading && (
+        <div className="d-flex justify-end text-small text-secondary padding-small">
+          <span>{t("evaluationServiceError")}</span>
+        </div>
+      )}
       <div ref={feedbackRef}>
         {feedback && (
           <div

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -285,6 +285,7 @@
     "yourAnswerHere": "Your answer here",
     "submitForReview": "Send for review",
     "evaluating": "Evaluating...",
+    "evaluationServiceError": "We couldn't evaluate your answer. Please try again.",
     "summarize": "Summarize",
     "removeThis": "Remove this",
     "sure?": "Sure?",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -291,6 +291,7 @@
     "yourAnswerHere": "Tu respuesta aquí",
     "submitForReview": "Enviar para revisión",
     "evaluating": "Evaluando...",
+    "evaluationServiceError": "No pudimos evaluar tu respuesta. Inténtalo de nuevo.",
     "summarize": "Resumir",
     "removeThis": "Eliminar este",
     "sure?": "¿Seguro?",


### PR DESCRIPTION
## Problema que resuelve
Cuando el servidor de Rigobot devolvía un error (p. ej. H12 / 503) o el webhook de evaluación no llegaba, el frontend se quedaba "colgado" indefinidamente con el botón en "Evaluando…", sin forma de recuperarse.

## Solución implementada
- Se maneja el caso de error del servidor en `onComplete` (antes solo se contemplaba el éxito), saliendo del estado de carga.
- Se añade un **watchdog** de 60s en `OpenQuestion`: si no hay respuesta, se cancela la evaluación y se libera el botón.
- Ambos casos (error o timeout) muestran un estado de **error de servicio** con botón **"Reintentar"**, conservando la respuesta del alumno y diferenciándose visualmente del feedback "tu respuesta necesita mejoras".
- `RigoAI.useTemplate` ahora devuelve el `job` para poder cancelar la suscripción al expirar el watchdog.
- Se registra un evento de GTM, pero no de telemetría, por lo que **no** cuenta como intento fallido del alumno.