### PR TITLE
refactor: decrease timeout to retry rigobot tests

### DIFF
--- a/src/components/composites/OpenQuestion/OpenQuestion.tsx
+++ b/src/components/composites/OpenQuestion/OpenQuestion.tsx
@@ -4,7 +4,12 @@ import { useTranslation } from "react-i18next";
 import { suggestExamples } from "../../../managers/EventProxy";
 import { Element } from "hast";
 import { useEffect, useRef, useState } from "react";
-import { asyncHashText, debounce, playEffect } from "../../../utils/lib";
+import {
+  asyncHashText,
+  debounce,
+  playEffect,
+  RIGOBOT_EVALUATION_TIMEOUT_MS,
+} from "../../../utils/lib";
 
 import { SpeechToTextButton } from "../SpeechRecognitionButton/SpeechRecognitionButton";
 
@@ -30,10 +35,6 @@ type TFeedback = {
   exit_code: number;
   feedback: string;
 };
-
-// If Rigobot doesn't respond within this window (e.g. H12 timeout where the
-// completion webhook never arrives), we stop waiting and offer a retry.
-const EVALUATION_TIMEOUT_MS = 60000;
 
 export const Question = ({
   metadata,
@@ -241,7 +242,7 @@ export const Question = ({
     clearWatchdog();
     watchdogRef.current = setTimeout(
       () => handleEvaluationFailure("timeout"),
-      EVALUATION_TIMEOUT_MS
+      RIGOBOT_EVALUATION_TIMEOUT_MS
     );
 
     jobRef.current = RigoAI.useTemplate({

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -133,6 +133,8 @@ getEnvironment();
 
 export const RIGOBOT_HOST = import.meta.env.VITE_RIGOBOT_HOST || "https://rigobot.herokuapp.com";
 // export const RIGOBOT_HOST = "https://8000-charlytoc-rigobot-bmwdeam7cev.ws-us120.gitpod.io";
+/** Max wait for Rigobot evaluation (tests, builds, open questions) before showing Retry. */
+export const RIGOBOT_EVALUATION_TIMEOUT_MS = 20000;
 export const BREATHECODE_HOST = "https://breathecode.herokuapp.com";
 
 export const changeSidebarVisibility = () => {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -48,7 +48,11 @@ import {
 } from "./storeTypes";
 import toast from "react-hot-toast";
 import { getStatus } from "../managers/socket";
-import { DEV_MODE, RIGOBOT_HOST } from "./lib";
+import {
+  DEV_MODE,
+  RIGOBOT_EVALUATION_TIMEOUT_MS,
+  RIGOBOT_HOST,
+} from "./lib";
 import { EventProxy } from "../managers/EventProxy";
 import { FetchManager } from "../managers/fetchManager";
 import {
@@ -742,7 +746,7 @@ const useStore = create<IStore>((set, get) => ({
     get().clearCompilationWatchdog();
     const id = setTimeout(() => {
       if (get().isCompiling) get().failCompilation();
-    }, 60000);
+    }, RIGOBOT_EVALUATION_TIMEOUT_MS);
     set({ compilationWatchdog: id });
   },
 


### PR DESCRIPTION
- Ahora que [se solucionó el error que causaba eventos H12 frecuentes en rigobot](https://github.com/breatheco-de/rigobot/pull/379), considero seguro disminuir a 20 segundos (antes 60) el tiempo de espera tras el cual el alumno puede reintentar (botón retry).