### PR TITLE
Corrige la carga del IDE dentro de un LMS (paquetes SCORM)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,6 +37,13 @@ const router = createBrowserRouter([
         path: "/preview/:slug/webview",
         element: <PreviewHTMLPage />,
       },
+      {
+        // Catch-all: el LMS sirve el SCO en una ruta base anidada (ej.
+        // /scorm/file/<hash>/config/index.html) que no matchea las rutas fijas.
+        // Renderiza <App/> dentro del <Layout> (TooltipProvider) para cualquier ruta.
+        path: "*",
+        element: <App />,
+      },
     ],
   },
 ]);
@@ -47,7 +54,10 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   </React.StrictMode>
 );
 
-if ("serviceWorker" in navigator) {
+// sw.js no se incluye en el paquete SCORM y su scope absoluto "/sw.js" falla bajo
+// la ruta anidada del LMS, así que se omite el registro cuando corremos como SCO.
+const isScormPath = window.location.pathname.endsWith("/config/index.html");
+if ("serviceWorker" in navigator && !isScormPath) {
   navigator.serviceWorker
     .register("/sw.js")
     .then((reg) => console.log("Service Worker registrado:", reg))

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -65,6 +65,34 @@ export const getEnvironment = async () => {
   const host = getHost();
 
   console.log("DETECTED HOST", host);
+
+  // SCORM SCO: el config vive en `${host}/.learn/config.json`. Se detecta de forma
+  // explícita y primero, porque algunos LMS devuelven un 404 con cuerpo JSON parseable
+  // en otras rutas, lo que haría que la detección legacy se quedara en "localStorage".
+  const includeScormPath = window.location.pathname.endsWith("/config/index.html");
+  if (includeScormPath) {
+    try {
+      const scormConfig = await fetch(`${host}/.learn/config.json`);
+      if (scormConfig.ok) {
+        await scormConfig.json();
+        ENVIRONMENT = "scorm";
+        document.dispatchEvent(
+          new CustomEvent("environment-change", {
+            detail: { environment: "scorm" },
+          })
+        );
+        console.log("The environment will be scorm");
+        return "scorm";
+      }
+    } catch (e) {
+      console.error(
+        "SCORM config fetch failed, falling back to legacy detection",
+        e
+      );
+    }
+    // si no se encontró, continúa con la detección legacy de abajo
+  }
+
   try {
     const slug = getSlugFromPath();
     const response = await fetch(`${host}/config?slug=${slug}`);
@@ -96,6 +124,7 @@ export const getEnvironment = async () => {
     // Fetch config,jsonhandleEnvironmentChange
     try {
       const config = await fetch(`${host}/config.json`);
+      if (!config.ok) throw new Error("config.json not found");
       await config.json();
 
       console.log("The environment will be localStorage");
@@ -112,8 +141,10 @@ export const getEnvironment = async () => {
       try {
         const scormConfig = await fetch(`${host}/.learn/config.json`);
         console.log("SCORM CONFIG PATH", scormConfig);
+        if (!scormConfig.ok) throw new Error(".learn/config.json not found");
         await scormConfig.json();
 
+        ENVIRONMENT = "scorm";
         const myEvent = new CustomEvent("environment-change", {
           detail: { environment: "scorm" },
         });


### PR DESCRIPTION
## Problema
El paquete SCORM no renderizaba dentro del LMS por dos causas en el IDE:
- El LMS sirve el contenido en una ruta anidada que no coincidía con ninguna route del router, por lo que caía al `errorElement` fuera del `TooltipProvider` → crash `Tooltip must be used within TooltipProvider`.
- La detección de entorno aceptaba como válido un `config.json` con respuesta 404 (cuerpo JSON), así que nunca llegaba a la rama `scorm` y se quedaba en `localStorage` sin datos.

## Solución
- `main.tsx`: nueva route catch-all (`path: "*"`) que renderiza la app bajo el `Layout`/`TooltipProvider` para cualquier ruta base; y se omite el registro del Service Worker (`/sw.js`) cuando corre como SCO.
- `lib.tsx` (`getEnvironment`): detecta `scorm` primero vía `.learn/config.json`, exige `response.ok` en todas las ramas y corrige un caso donde no se asignaba el entorno `scorm`.
- Sin cambios de comportamiento en `localhost`/`creatorWeb`/`localStorage`.