### PR TITLE
feat: reportar inicio, progreso y score al LMS en tiempo real (SCORM)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import TranslationListener from "./components/Creator/TranslationListener";
 import SyncNotificationListener from "./components/SyncNotifications/SyncNotificationListener";
 import PackageMetadataListener from "./components/PackageMetadataListener";
 import EventListener from "./managers/eventListener";
+import ScormReporter from "./managers/ScormReporter";
 import AppLoadingScreen from "./components/sections/AppLoadingScreen";
 export default function Home() {
   const start = useStore((s) => s.start);
@@ -69,6 +70,7 @@ export default function Home() {
       <NewHeader />
       <Container />
       <EventListener />
+      <ScormReporter />
     </main>
   );
 }

--- a/src/managers/ScormReporter.tsx
+++ b/src/managers/ScormReporter.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { eventBus } from "./eventBus";
+import TelemetryManager from "./telemetry";
+import useStore from "@/utils/store";
+import {
+  isScormEnvironment,
+  reportScormStarted,
+  reportScormProgress,
+} from "./scormBridge";
+
+/**
+ * Bridges the IDE's telemetry to the SCORM 1.2 run-time so the LMS records the
+ * learner's start, per-step progress/score and a bookmark — not just the final
+ * completion. Renders nothing.
+ *
+ * No-op outside SCORM: it only subscribes when running inside the exported SCORM
+ * package (detected via the `ScormProcess*` globals injected by config/api.js).
+ * Course completion stays in eventListener.tsx (`last_lesson_finished`).
+ */
+export default function ScormReporter() {
+  useEffect(() => {
+    if (!isScormEnvironment()) return;
+
+    // Register the attempt as started/in-progress as soon as the SCO mounts
+    // (LMSInitialize already ran in the wrapper's onload).
+    reportScormStarted();
+
+    // Push the live completion percentage (score) and the current step
+    // (bookmark) to the LMS whenever a step is completed or the learner
+    // navigates between lessons.
+    const sync = () => {
+      const rate = TelemetryManager.getCompletionRate();
+      const stepIndex = Number(useStore.getState().currentExercisePosition);
+      reportScormProgress(rate, stepIndex);
+    };
+
+    eventBus.on("step_completed", sync);
+    eventBus.on("position_changed", sync);
+
+    return () => {
+      eventBus.off("step_completed", sync);
+      eventBus.off("position_changed", sync);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/managers/ScormReporter.tsx
+++ b/src/managers/ScormReporter.tsx
@@ -15,7 +15,12 @@ import {
  *
  * No-op outside SCORM: it only subscribes when running inside the exported SCORM
  * package (detected via the `ScormProcess*` globals injected by config/api.js).
- * Course completion stays in eventListener.tsx (`last_lesson_finished`).
+ *
+ * Scope: this component handles only the CONTINUOUS signals (start, progress,
+ * bookmark). Course COMPLETION deliberately stays in eventListener.tsx, where the
+ * "course finished" decision already lives (`last_lesson_finished` guarded by
+ * `!hasPendingTasksInAnyLesson()`, alongside confetti and the modal). Keeping it
+ * there avoids duplicating that guard.
  */
 export default function ScormReporter() {
   useEffect(() => {

--- a/src/managers/scormBridge.ts
+++ b/src/managers/scormBridge.ts
@@ -37,6 +37,71 @@ const getScormWrapper = (): ScormWrapper | null => {
 
 export const isScormEnvironment = (): boolean => getScormWrapper() !== null;
 
+// Writes cmi.core.score.raw/min/max (0-100 CMIDecimal). Shared by progress and
+// completion reporting.
+const setScore = (scorm: ScormWrapper, percent: number): void => {
+  const clamped = Math.max(0, Math.min(100, Math.round(percent)));
+  scorm.ScormProcessSetValue?.("cmi.core.score.min", "0");
+  scorm.ScormProcessSetValue?.("cmi.core.score.max", "100");
+  scorm.ScormProcessSetValue?.("cmi.core.score.raw", String(clamped));
+};
+
+/**
+ * Marks the course as started/in-progress in the LMS.
+ *
+ * Sets `cmi.core.lesson_status = "incomplete"` and commits, so the LMS records
+ * the attempt as soon as the learner opens the course. Does NOT downgrade a
+ * returning learner who already finished (guards against "completed"/"passed").
+ */
+export const reportScormStarted = (): void => {
+  const scorm = getScormWrapper();
+  if (!scorm) return;
+
+  try {
+    const status = scorm.ScormProcessGetValue?.("cmi.core.lesson_status");
+    if (status === "completed" || status === "passed") return;
+
+    scorm.ScormProcessSetValue?.("cmi.core.lesson_status", "incomplete");
+    scorm.ScormProcessCommit?.();
+  } catch (error) {
+    console.error("Error reporting start to SCORM LMS", error);
+  }
+};
+
+/**
+ * Reports incremental progress to the LMS during the course.
+ *
+ * @param percent   0-100 completion percentage → `cmi.core.score.raw`.
+ * @param stepIndex Optional current step index → `cmi.core.lesson_location`
+ *                  (bookmark). When omitted, only the score is written.
+ *
+ * Intentionally does NOT touch `cmi.core.lesson_status` (it stays "incomplete"
+ * until `reportScormCompletion` marks it "completed"), so progress reporting can
+ * never overwrite the completion state.
+ */
+export const reportScormProgress = (
+  percent: number,
+  stepIndex?: number
+): void => {
+  const scorm = getScormWrapper();
+  if (!scorm) return;
+
+  try {
+    if (typeof percent === "number" && Number.isFinite(percent)) {
+      setScore(scorm, percent);
+    }
+    if (typeof stepIndex === "number" && Number.isFinite(stepIndex)) {
+      scorm.ScormProcessSetValue?.(
+        "cmi.core.lesson_location",
+        String(stepIndex)
+      );
+    }
+    scorm.ScormProcessCommit?.();
+  } catch (error) {
+    console.error("Error reporting progress to SCORM LMS", error);
+  }
+};
+
 /**
  * Reports course completion to the LMS.
  *
@@ -51,10 +116,7 @@ export const reportScormCompletion = (scorePercent?: number): void => {
     scorm.ScormProcessSetValue?.("cmi.core.lesson_status", "completed");
 
     if (typeof scorePercent === "number" && Number.isFinite(scorePercent)) {
-      const clamped = Math.max(0, Math.min(100, Math.round(scorePercent)));
-      scorm.ScormProcessSetValue?.("cmi.core.score.min", "0");
-      scorm.ScormProcessSetValue?.("cmi.core.score.max", "100");
-      scorm.ScormProcessSetValue?.("cmi.core.score.raw", String(clamped));
+      setScore(scorm, scorePercent);
     }
 
     scorm.ScormProcessCommit?.();

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -895,6 +895,7 @@ interface ITelemetryManager {
   hasPendingTasksInAnyLesson: () => boolean;
   isTesteable: (stepPosition: number) => boolean;
   isStepCompleted: (stepPosition: number) => boolean;
+  getCompletionRate: () => number;
   getStepIndicators: (stepPosition: number) => TStepIndicators | null;
   streamEvent: (stepPosition: number, event: string, data: any) => void;
   submit: () => Promise<void>;
@@ -1585,6 +1586,13 @@ const TelemetryManager: ITelemetryManager = {
 
   isStepCompleted: function (stepPosition: number) {
     return this.current?.steps[stepPosition]?.is_completed ?? false;
+  },
+
+  // Live course completion percentage (0-100) derived from the current blob.
+  // Reuses the same metrics pipeline used by submit().
+  getCompletionRate: function () {
+    if (!this.current) return 0;
+    return calculateIndicators(this.current).global.metrics.completion_rate;
   },
 
   hasPendingTasksInAnyLesson: function () {


### PR DESCRIPTION
## Problema que resuelve
El paquete SCORM solo reportaba el completado final: el LMS no registraba que el estudiante inició el curso, no mostraba progreso paso a paso y el score quedaba en `unknown` hasta terminar. La telemetría por paso que el IDE ya calcula no se mapeaba al modelo de datos de SCORM.

## Solución
- `scormBridge.ts`: nuevas `reportScormStarted()` (marca `lesson_status="incomplete"` + `Commit`, sin degradar a quien ya terminó) y `reportScormProgress(percent, stepIndex)` (escribe `score.raw` y `lesson_location`, sin tocar `lesson_status`).
- `telemetry.ts`: `getCompletionRate()` expone el % de avance en vivo reutilizando `calculateIndicators`.
- Nuevo `ScormReporter.tsx` (montado en `App.tsx`): al iniciar reporta el "started" y, en `step_completed`/`position_changed`, sincroniza score y bookmark del paso actual.
- Todo guardado tras `isScormEnvironment()` → no-op en `localhost`/`creatorWeb`/`localStorage`.
- La finalización sigue en `eventListener.tsx`, donde ya vive la decisión de "curso terminado" (guarda `!hasPendingTasksInAnyLesson()`, confetti y modal); mantenerla ahí evita duplicar esa validación. `ScormReporter` se ocupa solo de las señales continuas (inicio, progreso, bookmark).