### PR TITLE
feat: bloquear la finalización del curso si la telemetría no está inicializada

### DIFF
--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -17,6 +17,7 @@ const ContinueButton = () => {
   const editorTabs = useStore((s) => s.editorTabs);
   const agent = useStore((s) => s.agent);
   const exercises = useStore((s) => s.exercises);
+  const telemetryReady = useStore((s) => s.telemetryReady);
   const [loading, setLoading] = useState(false);
   const [, setCompletionTick] = useState(0);
   const isLastExercise = currentExercisePosition === exercises.length - 1;
@@ -28,7 +29,12 @@ const ContinueButton = () => {
 
   const hasPendingTasksInAnyLesson = TelemetryManager.hasPendingTasksInAnyLesson();
 
-  const isFinishDisabled = isLastExercise && (hasPendingTasks || hasPendingTasksInAnyLesson);
+  // Without telemetry we cannot know whether there are unanswered testeable
+  // elements, so completion is unverifiable → block Finish (fail-safe). Telemetry
+  // only becomes ready after a successful start, which requires being logged in.
+  const isFinishDisabled =
+    isLastExercise &&
+    (hasPendingTasks || hasPendingTasksInAnyLesson || !telemetryReady);
   const isDisabled = loading || isFinishDisabled;
 
   const hasBodyLessonLoader = () => {

--- a/src/managers/eventListener.tsx
+++ b/src/managers/eventListener.tsx
@@ -15,7 +15,11 @@ export default function EventListener() {
         eventBus.on("assessment_completed", (event) => {
             console.debug("assessment_completed", event);
             if (isLastExercise) {
+                // Without telemetry we cannot verify pending tasks, and client-side
+                // quizzes emit assessment_completed even for anonymous learners, so
+                // auto-finishing here would bypass the checks. Require telemetry.
                 if (event.status === "SUCCESS" &&
+                    useStore.getState().telemetryReady &&
                     !TelemetryManager.hasPendingTasks(currentExercisePosition) &&
                     !TelemetryManager.hasPendingTasksInAnyLesson()) {
                     eventBus.emit("last_lesson_finished", {});
@@ -25,6 +29,12 @@ export default function EventListener() {
 
         eventBus.on("last_lesson_finished", () => {
             console.debug("last_lesson_finished");
+            // Fail-safe backstop: never complete when telemetry is not initialized,
+            // since completion (and the SCORM report) cannot be verified.
+            if (!useStore.getState().telemetryReady) {
+                console.debug("Completion blocked: telemetry not initialized (cannot verify)");
+                return;
+            }
             // Verify again if there are pending tasks in any lesson
             if (!TelemetryManager.hasPendingTasksInAnyLesson()) {
                 // Mark the last step as complete if it hasn't been yet.


### PR DESCRIPTION
## Problema
Sin sesión, la telemetría no arranca y `hasPendingTasks`/`hasPendingTasksInAnyLesson` devuelven `false` (no hay datos que verificar). Así, en el entorno` scorm`, un alumno anónimo podía marcar el curso como completado sin responder los quizzes,  resolver los code challenges o recorrer todos los steps de solo lectura.

## Solución
- `LessonRenderer.tsx`: el botón Finish se deshabilita también cuando `!telemetryReady` (fail-safe).
- `eventListener.tsx`: se exige `telemetryReady` en ambos handlers (`assessment_completed` y `last_lesson_finished`), de modo que el completado (modal, confetti y reporte SCORM) nunca se ejecute sin verificación.

## Notas
- `telemetryReady` solo es `true` tras un arranque de telemetría exitoso, que requiere sesión → sin login no hay finalización. Sin regresión para usuarios logueados.
- Trade-off aceptado: un curso read-only anónimo tampoco podrá finalizarse (sin telemetría no se distingue de uno con quizzes).