### PR TITLE
feat(UX): el botón Finalizar sin sesión ahora ofrece iniciar sesión

### DIFF
--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -11,6 +11,11 @@ import RealtimeNotificationListener from "../../Creator/RealtimeNotificationList
 import { svgs } from "../../../assets/svgs";
 import TelemetryManager from "../../../managers/telemetry";
 import toast from "react-hot-toast";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const ContinueButton = () => {
   const { t } = useTranslation();
@@ -84,50 +89,57 @@ const ContinueButton = () => {
     };
   }, []);
 
-  return (
-    agent !== "vscode" &&
-    !hasBodyLessonLoader() && (
-      <div
-        aria-disabled={isDisabled}
-        className={`badge bg-blue  ${
-          editorTabs.length > 0 ? "hide-continue-button" : "continue-button"
-        }`}
-        role="button"
-        tabIndex={0}
-        title={finishTitle}
-        style={isDisabled ? { opacity: 0.6, cursor: "not-allowed" } : {}}
-        onClick={() => {
-          // Anonymous learner trying to finish: route them to the login modal
-          // instead of a dead button (mirrors the quiz login prompt).
-          if (needsLogin) {
-            toast.error(t("login-to-finish"));
-            setOpenedModals({ mustLogin: true });
-            return;
-          }
-          if (isDisabled) return;
-          setLoading(true);
-          if (isLastExercise) {
-            // If there are no pending tasks in any lesson, finish the lesson
-            if (!hasPendingTasksInAnyLesson) {
-              eventBus.emit("last_lesson_finished", {});
-            } else {
-              console.debug("Cannot finish: there are pending tasks in other lessons");
-              setLoading(false);
-            }
+  if (agent === "vscode" || hasBodyLessonLoader()) return null;
+
+  const buttonElement = (
+    <div
+      aria-disabled={isDisabled}
+      className={`badge bg-blue  ${
+        editorTabs.length > 0 ? "hide-continue-button" : "continue-button"
+      }`}
+      role="button"
+      tabIndex={0}
+      style={isDisabled ? { opacity: 0.6, cursor: "not-allowed" } : {}}
+      onClick={() => {
+        // Anonymous learner trying to finish: route them to the login modal
+        // instead of a dead button (mirrors the quiz login prompt).
+        if (needsLogin) {
+          toast.error(t("login-to-finish"));
+          setOpenedModals({ mustLogin: true });
+          return;
+        }
+        if (isDisabled) return;
+        setLoading(true);
+        if (isLastExercise) {
+          // If there are no pending tasks in any lesson, finish the lesson
+          if (!hasPendingTasksInAnyLesson) {
+            eventBus.emit("last_lesson_finished", {});
           } else {
-            eventBus.emit("position_change", {
-              position: Number(currentExercisePosition) + 1,
-            });
+            console.debug("Cannot finish: there are pending tasks in other lessons");
+            setLoading(false);
           }
-        }}
-      >
-        {loading
-          ? t("loading")
-          : isLastExercise
-          ? "Finish"
-          : t("continue")}
-      </div>
-    )
+        } else {
+          eventBus.emit("position_change", {
+            position: Number(currentExercisePosition) + 1,
+          });
+        }
+      }}
+    >
+      {loading ? t("loading") : isLastExercise ? "Finish" : t("continue")}
+    </div>
+  );
+
+  // Explain the button state (login needed / pending activities) via a shadcn
+  // tooltip, consistent with the rest of the app (see SimpleButton).
+  if (!finishTitle) return buttonElement;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{buttonElement}</TooltipTrigger>
+      <TooltipContent className="max-w-[200px]" side="top">
+        <p className="whitespace-normal break-words">{finishTitle}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 };
 

--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -10,6 +10,7 @@ import { fixLesson } from "../../../managers/EventProxy";
 import RealtimeNotificationListener from "../../Creator/RealtimeNotificationListener";
 import { svgs } from "../../../assets/svgs";
 import TelemetryManager from "../../../managers/telemetry";
+import toast from "react-hot-toast";
 
 const ContinueButton = () => {
   const { t } = useTranslation();
@@ -18,6 +19,8 @@ const ContinueButton = () => {
   const agent = useStore((s) => s.agent);
   const exercises = useStore((s) => s.exercises);
   const telemetryReady = useStore((s) => s.telemetryReady);
+  const token = useStore((s) => s.token);
+  const setOpenedModals = useStore((s) => s.setOpenedModals);
   const [loading, setLoading] = useState(false);
   const [, setCompletionTick] = useState(0);
   const isLastExercise = currentExercisePosition === exercises.length - 1;
@@ -32,10 +35,24 @@ const ContinueButton = () => {
   // Without telemetry we cannot know whether there are unanswered testeable
   // elements, so completion is unverifiable → block Finish (fail-safe). Telemetry
   // only becomes ready after a successful start, which requires being logged in.
-  const isFinishDisabled =
-    isLastExercise &&
-    (hasPendingTasks || hasPendingTasksInAnyLesson || !telemetryReady);
-  const isDisabled = loading || isFinishDisabled;
+  const hasPendingWork = hasPendingTasks || hasPendingTasksInAnyLesson;
+  // Anonymous learner at the end: keep the button clickable so it can open the
+  // login modal (needsLogin implies !telemetryReady, since telemetry requires login).
+  const needsLogin = isLastExercise && !token;
+  // Logged-in learner with unfinished activities: genuinely blocked.
+  const blockedByPending = isLastExercise && telemetryReady && hasPendingWork;
+  // Logged in but telemetry not ready yet (transient/failed): cannot verify → block.
+  const cannotVerifyLoggedIn = isLastExercise && !telemetryReady && !!token;
+  // needsLogin is deliberately NOT part of isDisabled: the button stays active so
+  // clicking it routes the learner to the login modal.
+  const isDisabled = loading || blockedByPending || cannotVerifyLoggedIn;
+
+  // Never leave the button state mute: explain why it is blocked / what to do.
+  const finishTitle = needsLogin
+    ? t("login-to-finish")
+    : blockedByPending || cannotVerifyLoggedIn
+    ? t("complete-activities-to-finish")
+    : undefined;
 
   const hasBodyLessonLoader = () => {
     const selector = ".lesson-loader";
@@ -77,8 +94,16 @@ const ContinueButton = () => {
         }`}
         role="button"
         tabIndex={0}
+        title={finishTitle}
         style={isDisabled ? { opacity: 0.6, cursor: "not-allowed" } : {}}
         onClick={() => {
+          // Anonymous learner trying to finish: route them to the login modal
+          // instead of a dead button (mirrors the quiz login prompt).
+          if (needsLogin) {
+            toast.error(t("login-to-finish"));
+            setOpenedModals({ mustLogin: true });
+            return;
+          }
           if (isDisabled) return;
           setLoading(true);
           if (isLastExercise) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -146,6 +146,8 @@
     "you-must-login-title": "Oops! Looks like you're not logged in.",
     "you-must-login-message": "To compile code on the web and use our AI mentor Rigobot, please log in first!",
     "to-access-this-course-you-need-to-login": "To access this course, you need to log in",
+    "login-to-finish": "Log in to record your progress and finish the course",
+    "complete-activities-to-finish": "Complete all activities to finish the course",
     "execute-my-code": "Execute my code",
     "test-my-code": "Test my code",
     "test-and-send": "Test & Send",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -152,6 +152,8 @@
     "exercises": "Ejercicios",
     "you-must-login-title": "¡Ups! Parece que no has iniciado sesión.",
     "you-must-login-message": "Para compilar código en la web y usar nuestro mentor AI Rigobot, ¡por favor inicia sesión primero!",
+    "login-to-finish": "Inicia sesión para registrar tu progreso y finalizar el curso",
+    "complete-activities-to-finish": "Completa todas las actividades para finalizar el curso",
     "execute-my-code": "Ejecutar mi código",
     "test-my-code": "Testear mi código",
     "test-and-send": "Testear & Enviar",


### PR DESCRIPTION
## Resumen

- En un curso abierto de forma anónima, el botón **Finalizar** del último paso quedaba deshabilitado sin explicación ni acceso al login. 
- Ahora es accionable: al pulsarlo abre el modal de inicio de sesión, como ya ocurre en los pasos con actividad evaluable.
- Además, si el botón está deshabilitado, ahora tiene tooltip que informa acerca de la causa (debe completar todas las actividades).

## Cambios

- **`ContinueButton` (`LessonRenderer.tsx`)**: se separan los motivos de bloqueo.
  - Anónimo al final: botón **clickeable** → aviso + modal de login (patrón de `QuizRenderer`).
  - Logueado con pendientes o telemetría sin inicializar: sigue **deshabilitado**.
- `tooltip` explicativo en el botón según el motivo, para que su estado nunca sea mudo.
- Nuevas claves i18n (`en`/`es`): `login-to-finish` y `complete-activities-to-finish`.