### PR TITLE
feat: recuperar evaluaciones Rigobot cuando Soketi falla

### DIFF
--- a/src/components/Rigobot/AI.tsx
+++ b/src/components/Rigobot/AI.tsx
@@ -1,5 +1,11 @@
 import toast from "react-hot-toast";
-import { FASTAPI_HOST } from "../../utils/lib";
+import {
+  FASTAPI_HOST,
+  RIGOBOT_PUSHER_PENDING_MAX_ATTEMPTS,
+  RIGOBOT_PUSHER_PENDING_POLL_INTERVAL_MS,
+  RIGOBOT_RESCUE_MAX_ATTEMPTS,
+  RIGOBOT_RESCUE_POLL_INTERVAL_MS,
+} from "../../utils/lib";
 import { getCompletionJob } from "@/utils/apiCalls";
 
 export type TRigoMessage = {
@@ -31,6 +37,11 @@ export type TAgentJob = {
   run: () => void;
 };
 
+export type TJobStartedContext = {
+  jobId: string;
+  attemptRescue: () => Promise<boolean>;
+};
+
 type TRigoTemplateParams = {
   templateSlug: string;
   payload?: Record<string, any>;
@@ -38,6 +49,7 @@ type TRigoTemplateParams = {
   target?: HTMLElement;
   onComplete?: (success: boolean, data: any) => void;
   onStart?: (data: { when: string; url: string }) => void;
+  onJobStarted?: (ctx: TJobStartedContext) => void;
   userToken: string;
   apiHost?: string;
   pusherKey?: string;
@@ -59,6 +71,12 @@ const rigoTemplateState = {
   pusherHost: rigoTemplateDefaults.pusherHost,
 };
 
+const isTerminalCompletionStatus = (status: string) =>
+  status === "SUCCESS" || status === "ERROR";
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 export const RigoTemplate = {
   use: ({
     templateSlug,
@@ -67,6 +85,7 @@ export const RigoTemplate = {
     target,
     onComplete,
     onStart,
+    onJobStarted,
     userToken,
     apiHost,
     pusherKey,
@@ -96,19 +115,82 @@ export const RigoTemplate = {
     let pusherClient: any = null;
     let channel: any = null;
     let started = false;
+    let settled = false;
+    let jobId = "";
     const resolvedApiHost = apiHost ?? rigoTemplateDefaults.apiHost;
     const resolvedSoketiKey = pusherKey ?? rigoTemplateDefaults.pusherKey;
     const resolvedPusherHost = pusherHost ?? rigoTemplateDefaults.pusherHost;
     const resolvedPusherPort = pusherPort ?? rigoTemplateDefaults.pusherPort;
-    return {
-      stop: () => {
+
+    const cleanupPusher = () => {
+      try {
         if (channel) {
           channel.unbind_all();
           channel.unsubscribe();
+          channel = null;
         }
         if (pusherClient) {
           pusherClient.disconnect();
+          pusherClient = null;
         }
+      } catch (error) {
+        console.debug("Error cleaning up pusher client", error);
+      }
+    };
+
+    const settle = (completionJob: any, eventData?: { answer?: string }) => {
+      if (settled) return;
+      settled = true;
+      if (target && eventData?.answer) {
+        target.innerHTML = eventData.answer;
+      }
+      cleanupPusher();
+      const success = completionJob.status === "SUCCESS";
+      onComplete?.(success, { data: completionJob });
+    };
+
+    const pollCompletionJob = async (
+      maxAttempts: number,
+      intervalMs: number
+    ) => {
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (settled) return null;
+        try {
+          const completionJob = await getCompletionJob(
+            userToken,
+            jobId,
+            resolvedApiHost
+          );
+          if (isTerminalCompletionStatus(completionJob.status)) {
+            return completionJob;
+          }
+        } catch (error) {
+          console.warn("Error fetching completion job", error);
+        }
+        if (attempt < maxAttempts - 1) {
+          await sleep(intervalMs);
+        }
+      }
+      return null;
+    };
+
+    const attemptRescue = async (): Promise<boolean> => {
+      if (settled) return true;
+      const completionJob = await pollCompletionJob(
+        RIGOBOT_RESCUE_MAX_ATTEMPTS,
+        RIGOBOT_RESCUE_POLL_INTERVAL_MS
+      );
+      if (completionJob) {
+        settle(completionJob);
+        return true;
+      }
+      return settled;
+    };
+
+    return {
+      stop: () => {
+        settled = true;
+        cleanupPusher();
       },
       run: async () => {
         // TEMP LOCAL: simulate Rigobot 503 to test error UX.
@@ -153,7 +235,7 @@ export const RigoTemplate = {
             return;
           }
           const data = await response.json();
-          const jobId = data.id;
+          jobId = data.id;
           if (!jobId) {
             onComplete?.(false, { error: "No job ID returned from API" });
             return;
@@ -171,40 +253,39 @@ export const RigoTemplate = {
             onComplete?.(true, data);
             return;
           }
+
+          onJobStarted?.({ jobId, attemptRescue });
+
           const channelName = `completion-job-${jobId}`;
           channel = pusherClient.subscribe(channelName);
           channel.bind("completion", async (eventData: any) => {
+            if (settled) return;
             if (!started) {
               started = true;
             }
-            const completionJob = await getCompletionJob(userToken, jobId, resolvedApiHost);
-            if (completionJob.status === "SUCCESS" || completionJob.status === "ERROR") {
-              if (target) {
-                target.innerHTML = eventData.answer || "";
-              }
-              const success = completionJob.status === "SUCCESS";
-              onComplete?.(success, {
-                data: completionJob
-              });
-              try {
-                channel.unbind_all();
-              channel.unsubscribe();
-              pusherClient.disconnect();
-              } catch (error: any) {
-                console.debug("Error unbinding pusher client", error);
-              }
+            const completionJob = await pollCompletionJob(
+              RIGOBOT_PUSHER_PENDING_MAX_ATTEMPTS,
+              RIGOBOT_PUSHER_PENDING_POLL_INTERVAL_MS
+            );
+            if (completionJob) {
+              settle(completionJob, eventData);
             }
           });
           pusherClient.connection.bind("error", (err: any) => {
-            onComplete?.(false, { error: err?.error?.message || "Pusher connection error" });
+            if (settled) return;
+            settled = true;
+            cleanupPusher();
+            onComplete?.(false, {
+              error: err?.error?.message || "Pusher connection error",
+            });
           });
         } catch (error: any) {
-          onComplete?.(false, {
-            error: error?.message || "Unknown error occurred",
-          });
-          if (pusherClient) {
-            pusherClient.disconnect();
+          if (!settled) {
+            onComplete?.(false, {
+              error: error?.message || "Unknown error occurred",
+            });
           }
+          cleanupPusher();
         }
       },
     };
@@ -216,7 +297,7 @@ export const RigoAI = {
   load: () => {
     // @ts-ignore
     if (window.rigo) {
-      console.log("RigoAI already started, skipping load");
+      console.log("RigoAI already started, skipping");
       return;
     }
     const rigoAI = document.createElement("script");
@@ -267,7 +348,6 @@ export const RigoAI = {
           },
           context: context || "",
           sockethost: FASTAPI_HOST,
-          // sockethost: "http://127.0.0.1:8003",
         });
         // @ts-ignore
         window.rigo.show({
@@ -276,7 +356,6 @@ export const RigoAI = {
         });
         rigoTemplateState.userToken = userToken;
       } else {
-
         console.error(
           `No window.rigo found, initializing RigoAI failed, retrying in ${1000 * (retries + 1)
           }ms`
@@ -297,11 +376,13 @@ export const RigoAI = {
     inputs,
     target,
     onComplete,
+    onJobStarted,
   }: {
     slug: string;
     inputs: Record<string, string>;
     target?: HTMLElement;
     onComplete?: (success: boolean, data: any) => void;
+    onJobStarted?: (ctx: TJobStartedContext) => void;
   }): TAgentJob | undefined => {
     // @ts-ignore
     if (!window.rigo) {
@@ -319,10 +400,9 @@ export const RigoAI = {
       onComplete: (success: boolean, data: any) => {
         if (onComplete) onComplete(success, data);
       },
+      onJobStarted,
       userToken: rigoTemplateState.userToken,
-      // userToken: "bf535a2d08e685f5d2dbd810d3f509a90c63cfe3",
       apiHost: rigoTemplateState.apiHost,
-      // apiHost: "https://rigobot-test-cca7d841c9d8.herokuapp.com",
       pusherKey: rigoTemplateState.pusherKey,
       pusherHost: rigoTemplateState.pusherHost,
     });

--- a/src/components/composites/OpenQuestion/OpenQuestion.tsx
+++ b/src/components/composites/OpenQuestion/OpenQuestion.tsx
@@ -90,6 +90,7 @@ export const Question = ({
   const isRestoredFeedbackRef = useRef(false);
   const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const jobRef = useRef<TAgentJob | undefined>(undefined);
+  const attemptRescueRef = useRef<(() => Promise<boolean>) | null>(null);
   // Ensures only the first outcome (success / server error / timeout) wins, so a
   // webhook arriving after the timeout can't reprocess a settled evaluation.
   const settledRef = useRef(false);
@@ -239,11 +240,15 @@ export const Question = ({
     setFeedback(null);
     setIsLoading(true);
 
+    jobRef.current?.stop();
+    attemptRescueRef.current = null;
     clearWatchdog();
-    watchdogRef.current = setTimeout(
-      () => handleEvaluationFailure("timeout"),
-      RIGOBOT_EVALUATION_TIMEOUT_MS
-    );
+    watchdogRef.current = setTimeout(async () => {
+      const rescued = await attemptRescueRef.current?.();
+      if (!rescued && !settledRef.current) {
+        handleEvaluationFailure("timeout");
+      }
+    }, RIGOBOT_EVALUATION_TIMEOUT_MS);
 
     jobRef.current = RigoAI.useTemplate({
       slug: "evaluator",
@@ -252,6 +257,9 @@ export const Question = ({
         lesson_content: wholeMD,
         student_response: answer,
         examples: examples.join("\n"),
+      },
+      onJobStarted: ({ attemptRescue }) => {
+        attemptRescueRef.current = attemptRescue;
       },
       onComplete: (success, rigoData) => {
         if (settledRef.current) return;
@@ -325,6 +333,7 @@ export const Question = ({
   useEffect(() => {
     return () => {
       clearWatchdog();
+      attemptRescueRef.current = null;
       jobRef.current?.stop();
     };
   }, []);

--- a/src/managers/EventProxy.ts
+++ b/src/managers/EventProxy.ts
@@ -13,8 +13,9 @@ import {
 import { FetchManager } from "./fetchManager";
 import { LocalStorage } from "./localStorage";
 import Socket from "./socket";
-import { RigoAI } from "../components/Rigobot/AI";
+import { RigoAI, TAgentJob } from "../components/Rigobot/AI";
 import { DEV_MODE } from "../utils/lib";
+import useStore from "../utils/store";
 
 export type TEnvironment =
   | "localhost"
@@ -143,6 +144,8 @@ const RETRYABLE_STATUSES = [502, 503, 504];
 const MAX_RETRIES = 2;
 const BACKOFF_MS = [1000, 2000];
 
+let activeTemplateJob: TAgentJob | undefined;
+
 function runTemplateWithRetry(
   {
     slug,
@@ -158,13 +161,20 @@ function runTemplateWithRetry(
   onSuccess: (json: any) => void,
   attempt = 0
 ) {
-  RigoAI.useTemplate({
+  activeTemplateJob?.stop();
+
+  activeTemplateJob = RigoAI.useTemplate({
     slug,
     inputs,
     target,
+    onJobStarted: ({ attemptRescue }) => {
+      useStore.getState().setEvaluationRescue(attemptRescue);
+    },
     onComplete: (success, rigoData) => {
       const parsed = rigoData?.data?.parsed;
       if (success && parsed) {
+        useStore.getState().setEvaluationRescue(null);
+        activeTemplateJob = undefined;
         onSuccess(parsed);
         return;
       }
@@ -173,6 +183,9 @@ function runTemplateWithRetry(
       const isRetryable =
         status === undefined || RETRYABLE_STATUSES.includes(status);
       if (isRetryable && attempt < MAX_RETRIES) {
+        activeTemplateJob?.stop();
+        activeTemplateJob = undefined;
+        useStore.getState().setEvaluationRescue(null);
         localStorageEventEmitter.emitStatus("retrying", {
           targetButton,
           attempt: attempt + 1,
@@ -188,6 +201,8 @@ function runTemplateWithRetry(
         );
         return;
       }
+      useStore.getState().setEvaluationRescue(null);
+      activeTemplateJob = undefined;
       localStorageEventEmitter.emitStatus("service-error", {
         targetButton,
         error: rigoData?.error,

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -166,6 +166,14 @@ export const RIGOBOT_HOST = import.meta.env.VITE_RIGOBOT_HOST || "https://rigobo
 // export const RIGOBOT_HOST = "https://8000-charlytoc-rigobot-bmwdeam7cev.ws-us120.gitpod.io";
 /** Max wait for Rigobot evaluation (tests, builds, open questions) before showing Retry. */
 export const RIGOBOT_EVALUATION_TIMEOUT_MS = 20000;
+/** HTTP rescue poll interval after the evaluation watchdog fires (Pusher may have failed). */
+export const RIGOBOT_RESCUE_POLL_INTERVAL_MS = 2000;
+/** Max HTTP polls during a rescue burst after watchdog timeout. */
+export const RIGOBOT_RESCUE_MAX_ATTEMPTS = 3;
+/** Poll interval when Pusher fires but the completion job is still PENDING. */
+export const RIGOBOT_PUSHER_PENDING_POLL_INTERVAL_MS = 1000;
+/** Max polls while waiting for a PENDING job to reach a terminal status. */
+export const RIGOBOT_PUSHER_PENDING_MAX_ATTEMPTS = 3;
 export const BREATHECODE_HOST = "https://breathecode.herokuapp.com";
 
 export const changeSidebarVisibility = () => {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -337,6 +337,7 @@ const useStore = create<IStore>((set, get) => ({
   },
   isCompiling: false,
   compilationWatchdog: null as ReturnType<typeof setTimeout> | null,
+  evaluationRescue: null as (() => Promise<boolean>) | null,
   serviceError: false,
   showSidebar: false,
   user_id: null,
@@ -542,6 +543,7 @@ const useStore = create<IStore>((set, get) => ({
 
     const debounceTestingSuccess = debounce((data: any) => {
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
       const stdout = removeSpecialCharacters(data.logs[0]);
 
       setTestResult("successful", stdout);
@@ -584,6 +586,7 @@ const useStore = create<IStore>((set, get) => ({
 
     const debounceTestingError = debounce((data: any) => {
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
       const stdout = removeSpecialCharacters(data.logs[0]);
       set({ isCompiling: false, serviceError: false });
       setTestResult("failed", stdout);
@@ -626,6 +629,7 @@ const useStore = create<IStore>((set, get) => ({
     let compilerErrorHandler = debounce(async (data: any) => {
       data;
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
 
       set({ lastState: "error", terminalShouldShow: true });
       set({ isCompiling: false, serviceError: false });
@@ -645,6 +649,7 @@ const useStore = create<IStore>((set, get) => ({
     let compilerSuccessHandler = debounce(async (data: any) => {
       data;
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
       set({ lastState: "success", terminalShouldShow: true });
       set({ isCompiling: false, serviceError: false });
 
@@ -744,7 +749,13 @@ const useStore = create<IStore>((set, get) => ({
 
   startCompilationWatchdog: () => {
     get().clearCompilationWatchdog();
-    const id = setTimeout(() => {
+    const id = setTimeout(async () => {
+      if (!get().isCompiling) return;
+      const rescue = get().evaluationRescue;
+      if (rescue) {
+        const rescued = await rescue();
+        if (rescued) return;
+      }
       if (get().isCompiling) get().failCompilation();
     }, RIGOBOT_EVALUATION_TIMEOUT_MS);
     set({ compilationWatchdog: id });
@@ -756,6 +767,10 @@ const useStore = create<IStore>((set, get) => ({
     set({ compilationWatchdog: null });
   },
 
+  setEvaluationRescue: (fn) => {
+    set({ evaluationRescue: fn });
+  },
+
   failCompilation: () => {
     const {
       setFeedbackButtonProps,
@@ -765,7 +780,12 @@ const useStore = create<IStore>((set, get) => ({
       clearCompilationWatchdog,
     } = get();
     clearCompilationWatchdog();
-    set({ isCompiling: false, lastState: "error", serviceError: true });
+    set({
+      isCompiling: false,
+      lastState: "error",
+      serviceError: true,
+      evaluationRescue: null,
+    });
     if (targetButtonForFeedback === "feedback") {
       setFeedbackButtonProps("retry", "bg-fail text-white");
     } else {

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -348,6 +348,8 @@ export interface IStore {
   rigoContext: TRigoContext;
   isCompiling: boolean;
   compilationWatchdog: ReturnType<typeof setTimeout> | null;
+  /** HTTP rescue invoked by the watchdog when Pusher may have failed to deliver. */
+  evaluationRescue: (() => Promise<boolean>) | null;
   /** True only when the last run failed due to a service/infrastructure error (e.g. Rigobot 503), not the student's code. */
   serviceError: boolean;
   showSidebar: boolean;
@@ -407,6 +409,7 @@ export interface IStore {
   setFeedbackButtonProps: (t: string, c: string) => void;
   startCompilationWatchdog: () => void;
   clearCompilationWatchdog: () => void;
+  setEvaluationRescue: (fn: (() => Promise<boolean>) | null) => void;
   failCompilation: () => void;
   fetchSingleExerciseInfo: (index: number) => Promise<TExercise>;
   toggleFeedback: () => void;


### PR DESCRIPTION
## Problema que resuelve

En entornos SCORM, a partir del segundo intento de test, la respuesta de Rigobot nunca llegaba al frontend por un fallo silencioso en la conexión WebSocket (Soketi). Esto disparaba el timeout de 20s y mostraba el botón Retry aunque el resultado
ya estaba listo en el servidor.

## Solución implementada

- Al dispararse el timeout, se hace GETs HTTP a Rigobot antes de  mostrar Retry; si el job ya terminó, se procesa el resultado normalmente.
- Si el evento Pusher llega pero el job aún está `PENDING`, se reintenta el GET, hasta obtener un estado terminal (máximo 3 intentos).
- El job Pusher anterior se cierra explícitamente antes de cada nuevo intento,  evitando la acumulación de conexiones WebSocket entre reintentos.
- Se centraliza el cierre del job con un flag `settled` para evitar que Pusher y  el rescate HTTP procesen el mismo resultado dos veces.