### PR TITLE
fix: alinear SCORM con localStorage en telemetría, consumibles IA y Rigobot

### DIFF
--- a/src/components/Rigobot/AI.tsx
+++ b/src/components/Rigobot/AI.tsx
@@ -1,5 +1,11 @@
 import toast from "react-hot-toast";
-import { FASTAPI_HOST } from "../../utils/lib";
+import {
+  FASTAPI_HOST,
+  RIGOBOT_PUSHER_PENDING_MAX_ATTEMPTS,
+  RIGOBOT_PUSHER_PENDING_POLL_INTERVAL_MS,
+  RIGOBOT_RESCUE_MAX_ATTEMPTS,
+  RIGOBOT_RESCUE_POLL_INTERVAL_MS,
+} from "../../utils/lib";
 import { getCompletionJob } from "@/utils/apiCalls";
 
 export type TRigoMessage = {
@@ -31,6 +37,11 @@ export type TAgentJob = {
   run: () => void;
 };
 
+export type TJobStartedContext = {
+  jobId: string;
+  attemptRescue: () => Promise<boolean>;
+};
+
 type TRigoTemplateParams = {
   templateSlug: string;
   payload?: Record<string, any>;
@@ -38,6 +49,7 @@ type TRigoTemplateParams = {
   target?: HTMLElement;
   onComplete?: (success: boolean, data: any) => void;
   onStart?: (data: { when: string; url: string }) => void;
+  onJobStarted?: (ctx: TJobStartedContext) => void;
   userToken: string;
   apiHost?: string;
   pusherKey?: string;
@@ -59,6 +71,12 @@ const rigoTemplateState = {
   pusherHost: rigoTemplateDefaults.pusherHost,
 };
 
+const isTerminalCompletionStatus = (status: string) =>
+  status === "SUCCESS" || status === "ERROR";
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 export const RigoTemplate = {
   use: ({
     templateSlug,
@@ -67,6 +85,7 @@ export const RigoTemplate = {
     target,
     onComplete,
     onStart,
+    onJobStarted,
     userToken,
     apiHost,
     pusherKey,
@@ -96,19 +115,82 @@ export const RigoTemplate = {
     let pusherClient: any = null;
     let channel: any = null;
     let started = false;
+    let settled = false;
+    let jobId = "";
     const resolvedApiHost = apiHost ?? rigoTemplateDefaults.apiHost;
     const resolvedSoketiKey = pusherKey ?? rigoTemplateDefaults.pusherKey;
     const resolvedPusherHost = pusherHost ?? rigoTemplateDefaults.pusherHost;
     const resolvedPusherPort = pusherPort ?? rigoTemplateDefaults.pusherPort;
-    return {
-      stop: () => {
+
+    const cleanupPusher = () => {
+      try {
         if (channel) {
           channel.unbind_all();
           channel.unsubscribe();
+          channel = null;
         }
         if (pusherClient) {
           pusherClient.disconnect();
+          pusherClient = null;
         }
+      } catch (error) {
+        console.debug("Error cleaning up pusher client", error);
+      }
+    };
+
+    const settle = (completionJob: any, eventData?: { answer?: string }) => {
+      if (settled) return;
+      settled = true;
+      if (target && eventData?.answer) {
+        target.innerHTML = eventData.answer;
+      }
+      cleanupPusher();
+      const success = completionJob.status === "SUCCESS";
+      onComplete?.(success, { data: completionJob });
+    };
+
+    const pollCompletionJob = async (
+      maxAttempts: number,
+      intervalMs: number
+    ) => {
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (settled) return null;
+        try {
+          const completionJob = await getCompletionJob(
+            userToken,
+            jobId,
+            resolvedApiHost
+          );
+          if (isTerminalCompletionStatus(completionJob.status)) {
+            return completionJob;
+          }
+        } catch (error) {
+          console.warn("Error fetching completion job", error);
+        }
+        if (attempt < maxAttempts - 1) {
+          await sleep(intervalMs);
+        }
+      }
+      return null;
+    };
+
+    const attemptRescue = async (): Promise<boolean> => {
+      if (settled) return true;
+      const completionJob = await pollCompletionJob(
+        RIGOBOT_RESCUE_MAX_ATTEMPTS,
+        RIGOBOT_RESCUE_POLL_INTERVAL_MS
+      );
+      if (completionJob) {
+        settle(completionJob);
+        return true;
+      }
+      return settled;
+    };
+
+    return {
+      stop: () => {
+        settled = true;
+        cleanupPusher();
       },
       run: async () => {
         // TEMP LOCAL: simulate Rigobot 503 to test error UX.
@@ -153,7 +235,7 @@ export const RigoTemplate = {
             return;
           }
           const data = await response.json();
-          const jobId = data.id;
+          jobId = data.id;
           if (!jobId) {
             onComplete?.(false, { error: "No job ID returned from API" });
             return;
@@ -171,40 +253,39 @@ export const RigoTemplate = {
             onComplete?.(true, data);
             return;
           }
+
+          onJobStarted?.({ jobId, attemptRescue });
+
           const channelName = `completion-job-${jobId}`;
           channel = pusherClient.subscribe(channelName);
           channel.bind("completion", async (eventData: any) => {
+            if (settled) return;
             if (!started) {
               started = true;
             }
-            const completionJob = await getCompletionJob(userToken, jobId, resolvedApiHost);
-            if (completionJob.status === "SUCCESS" || completionJob.status === "ERROR") {
-              if (target) {
-                target.innerHTML = eventData.answer || "";
-              }
-              const success = completionJob.status === "SUCCESS";
-              onComplete?.(success, {
-                data: completionJob
-              });
-              try {
-                channel.unbind_all();
-              channel.unsubscribe();
-              pusherClient.disconnect();
-              } catch (error: any) {
-                console.debug("Error unbinding pusher client", error);
-              }
+            const completionJob = await pollCompletionJob(
+              RIGOBOT_PUSHER_PENDING_MAX_ATTEMPTS,
+              RIGOBOT_PUSHER_PENDING_POLL_INTERVAL_MS
+            );
+            if (completionJob) {
+              settle(completionJob, eventData);
             }
           });
           pusherClient.connection.bind("error", (err: any) => {
-            onComplete?.(false, { error: err?.error?.message || "Pusher connection error" });
+            if (settled) return;
+            settled = true;
+            cleanupPusher();
+            onComplete?.(false, {
+              error: err?.error?.message || "Pusher connection error",
+            });
           });
         } catch (error: any) {
-          onComplete?.(false, {
-            error: error?.message || "Unknown error occurred",
-          });
-          if (pusherClient) {
-            pusherClient.disconnect();
+          if (!settled) {
+            onComplete?.(false, {
+              error: error?.message || "Unknown error occurred",
+            });
           }
+          cleanupPusher();
         }
       },
     };
@@ -216,7 +297,7 @@ export const RigoAI = {
   load: () => {
     // @ts-ignore
     if (window.rigo) {
-      console.log("RigoAI already started, skipping load");
+      console.log("RigoAI already started, skipping");
       return;
     }
     const rigoAI = document.createElement("script");
@@ -267,7 +348,6 @@ export const RigoAI = {
           },
           context: context || "",
           sockethost: FASTAPI_HOST,
-          // sockethost: "http://127.0.0.1:8003",
         });
         // @ts-ignore
         window.rigo.show({
@@ -276,7 +356,6 @@ export const RigoAI = {
         });
         rigoTemplateState.userToken = userToken;
       } else {
-
         console.error(
           `No window.rigo found, initializing RigoAI failed, retrying in ${1000 * (retries + 1)
           }ms`
@@ -297,11 +376,13 @@ export const RigoAI = {
     inputs,
     target,
     onComplete,
+    onJobStarted,
   }: {
     slug: string;
     inputs: Record<string, string>;
     target?: HTMLElement;
     onComplete?: (success: boolean, data: any) => void;
+    onJobStarted?: (ctx: TJobStartedContext) => void;
   }): TAgentJob | undefined => {
     // @ts-ignore
     if (!window.rigo) {
@@ -319,10 +400,9 @@ export const RigoAI = {
       onComplete: (success: boolean, data: any) => {
         if (onComplete) onComplete(success, data);
       },
+      onJobStarted,
       userToken: rigoTemplateState.userToken,
-      // userToken: "bf535a2d08e685f5d2dbd810d3f509a90c63cfe3",
       apiHost: rigoTemplateState.apiHost,
-      // apiHost: "https://rigobot-test-cca7d841c9d8.herokuapp.com",
       pusherKey: rigoTemplateState.pusherKey,
       pusherHost: rigoTemplateState.pusherHost,
     });

--- a/src/components/composites/Editor/Editor.tsx
+++ b/src/components/composites/Editor/Editor.tsx
@@ -28,6 +28,7 @@ import { deleteFile } from "../../../utils/creator";
 import { Icon } from "../../Icon";
 import toast from "react-hot-toast";
 import { configureMonacoTypeScript } from "../../../utils/monacoTsConfig";
+import { isWebStudentEnvironment } from "../../../utils/lib";
 
 const languageMap: { [key: string]: string } = {
   ".js": "javascript",
@@ -780,10 +781,7 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
                     }
                     const exDoneReadonly = getCurrentExercise();
                     const grading = configObject.config?.grading;
-                    const isWebStudent =
-                      environment === "localStorage" ||
-                      environment === "scorm" ||
-                      (environment === "creatorWeb" && mode !== "creator");
+                    const isWebStudent = isWebStudentEnvironment(environment, mode);
                     const gradingStr = grading != null ? String(grading).trim() : "";
                     const showDoneReadonlyBanner =
                       exDoneReadonly.done &&

--- a/src/components/composites/Editor/Editor.tsx
+++ b/src/components/composites/Editor/Editor.tsx
@@ -782,6 +782,7 @@ const CodeEditor: React.FC<TCodeEditorProps> = ({
                     const grading = configObject.config?.grading;
                     const isWebStudent =
                       environment === "localStorage" ||
+                      environment === "scorm" ||
                       (environment === "creatorWeb" && mode !== "creator");
                     const gradingStr = grading != null ? String(grading).trim() : "";
                     const showDoneReadonlyBanner =

--- a/src/components/composites/OpenQuestion/OpenQuestion.tsx
+++ b/src/components/composites/OpenQuestion/OpenQuestion.tsx
@@ -90,6 +90,7 @@ export const Question = ({
   const isRestoredFeedbackRef = useRef(false);
   const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const jobRef = useRef<TAgentJob | undefined>(undefined);
+  const attemptRescueRef = useRef<(() => Promise<boolean>) | null>(null);
   // Ensures only the first outcome (success / server error / timeout) wins, so a
   // webhook arriving after the timeout can't reprocess a settled evaluation.
   const settledRef = useRef(false);
@@ -239,11 +240,15 @@ export const Question = ({
     setFeedback(null);
     setIsLoading(true);
 
+    jobRef.current?.stop();
+    attemptRescueRef.current = null;
     clearWatchdog();
-    watchdogRef.current = setTimeout(
-      () => handleEvaluationFailure("timeout"),
-      RIGOBOT_EVALUATION_TIMEOUT_MS
-    );
+    watchdogRef.current = setTimeout(async () => {
+      const rescued = await attemptRescueRef.current?.();
+      if (!rescued && !settledRef.current) {
+        handleEvaluationFailure("timeout");
+      }
+    }, RIGOBOT_EVALUATION_TIMEOUT_MS);
 
     jobRef.current = RigoAI.useTemplate({
       slug: "evaluator",
@@ -252,6 +257,9 @@ export const Question = ({
         lesson_content: wholeMD,
         student_response: answer,
         examples: examples.join("\n"),
+      },
+      onJobStarted: ({ attemptRescue }) => {
+        attemptRescueRef.current = attemptRescue;
       },
       onComplete: (success, rigoData) => {
         if (settledRef.current) return;
@@ -325,6 +333,7 @@ export const Question = ({
   useEffect(() => {
     return () => {
       clearWatchdog();
+      attemptRescueRef.current = null;
       jobRef.current?.stop();
     };
   }, []);

--- a/src/managers/EventProxy.ts
+++ b/src/managers/EventProxy.ts
@@ -13,8 +13,9 @@ import {
 import { FetchManager } from "./fetchManager";
 import { LocalStorage } from "./localStorage";
 import Socket from "./socket";
-import { RigoAI } from "../components/Rigobot/AI";
+import { RigoAI, TAgentJob } from "../components/Rigobot/AI";
 import { DEV_MODE } from "../utils/lib";
+import useStore from "../utils/store";
 
 export type TEnvironment =
   | "localhost"
@@ -143,6 +144,8 @@ const RETRYABLE_STATUSES = [502, 503, 504];
 const MAX_RETRIES = 2;
 const BACKOFF_MS = [1000, 2000];
 
+let activeTemplateJob: TAgentJob | undefined;
+
 function runTemplateWithRetry(
   {
     slug,
@@ -158,13 +161,20 @@ function runTemplateWithRetry(
   onSuccess: (json: any) => void,
   attempt = 0
 ) {
-  RigoAI.useTemplate({
+  activeTemplateJob?.stop();
+
+  activeTemplateJob = RigoAI.useTemplate({
     slug,
     inputs,
     target,
+    onJobStarted: ({ attemptRescue }) => {
+      useStore.getState().setEvaluationRescue(attemptRescue);
+    },
     onComplete: (success, rigoData) => {
       const parsed = rigoData?.data?.parsed;
       if (success && parsed) {
+        useStore.getState().setEvaluationRescue(null);
+        activeTemplateJob = undefined;
         onSuccess(parsed);
         return;
       }
@@ -173,6 +183,9 @@ function runTemplateWithRetry(
       const isRetryable =
         status === undefined || RETRYABLE_STATUSES.includes(status);
       if (isRetryable && attempt < MAX_RETRIES) {
+        activeTemplateJob?.stop();
+        activeTemplateJob = undefined;
+        useStore.getState().setEvaluationRescue(null);
         localStorageEventEmitter.emitStatus("retrying", {
           targetButton,
           attempt: attempt + 1,
@@ -188,6 +201,8 @@ function runTemplateWithRetry(
         );
         return;
       }
+      useStore.getState().setEvaluationRescue(null);
+      activeTemplateJob = undefined;
       localStorageEventEmitter.emitStatus("service-error", {
         targetButton,
         error: rigoData?.error,

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -10,6 +10,7 @@ import {
   DEV_MODE,
   getReadmeExtension,
   ENVIRONMENT,
+  isWebTelemetryEnvironment,
 } from "../utils/lib";
 import { TEnvironment } from "./EventProxy";
 import frontMatter from "front-matter";
@@ -747,10 +748,7 @@ export const FetchManager = {
         token: breathecodeToken,
         tabHash: tabHash,
       });
-    } else if (
-      FetchManager.ENVIRONMENT === "localStorage" ||
-      FetchManager.ENVIRONMENT === "creatorWeb"
-    ) {
+    } else if (isWebTelemetryEnvironment(FetchManager.ENVIRONMENT as TEnvironment)) {
       LocalStorage.set("session", {
         token: breathecodeToken,
         user_id: loggedFormat.user_id,

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -170,10 +170,35 @@ export const FetchManager = {
       },
 
       scorm: async () => {
+        let edited = false;
         const url = `${FetchManager.HOST}/exercises/${slug}/${file}`;
         const response = await fetch(url);
         const fileContent = await response.text();
-        return { fileContent, edited: false };
+
+        if (opts.cached) {
+          const state = useStore.getState();
+          const exercise = state.exercises.find((e) => e.slug === slug);
+
+          if (exercise?.done && exercise?.approved_solution_files) {
+            const approvedFile = exercise.approved_solution_files.find(
+              (f) => f.name === file
+            );
+            if (approvedFile) {
+              return { fileContent: approvedFile.content, edited: true };
+            }
+          }
+
+          const cachedEditorTabs = LocalStorage.get(`editorTabs_${slug}`);
+          if (cachedEditorTabs) {
+            const cached = cachedEditorTabs.find((t: TEditorTab) => t.name === file);
+            if (cached) {
+              edited = true;
+              return { fileContent: cached.content, edited };
+            }
+          }
+        }
+
+        return { fileContent, edited };
       },
 
       creatorWeb: async () => {

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -13,6 +13,27 @@ export const DEV_MODE =false;
 export const DEV_URL = import.meta.env.VITE_DEV_URL || "https://1gm40gnb-3000.use2.devtunnels.ms";
 export const LEARNPACK_LOCAL_URL = DEV_MODE ? "http://localhost:3000" : "";
 
+/** Student-facing web envs: localStorage, SCORM, creatorWeb in student mode. */
+export function isWebStudentEnvironment(
+  environment: TEnvironment,
+  mode?: string
+): boolean {
+  return (
+    environment === "localStorage" ||
+    environment === "scorm" ||
+    (environment === "creatorWeb" && mode !== "creator")
+  );
+}
+
+/** Web envs where client-side telemetry/testeable registration applies. */
+export function isWebTelemetryEnvironment(environment: TEnvironment): boolean {
+  return (
+    environment === "localStorage" ||
+    environment === "scorm" ||
+    environment === "creatorWeb"
+  );
+}
+
 export const FASTAPI_HOST = "https://ai.4geeks.com";
 // export const FASTAPI_HOST = "http://localhost:8003";
 //@ts-ignore

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -166,6 +166,14 @@ export const RIGOBOT_HOST = import.meta.env.VITE_RIGOBOT_HOST || "https://rigobo
 // export const RIGOBOT_HOST = "https://8000-charlytoc-rigobot-bmwdeam7cev.ws-us120.gitpod.io";
 /** Max wait for Rigobot evaluation (tests, builds, open questions) before showing Retry. */
 export const RIGOBOT_EVALUATION_TIMEOUT_MS = 20000;
+/** HTTP rescue poll interval after the evaluation watchdog fires (Pusher may have failed). */
+export const RIGOBOT_RESCUE_POLL_INTERVAL_MS = 2000;
+/** Max HTTP polls during a rescue burst after watchdog timeout. */
+export const RIGOBOT_RESCUE_MAX_ATTEMPTS = 3;
+/** Poll interval when Pusher fires but the completion job is still PENDING. */
+export const RIGOBOT_PUSHER_PENDING_POLL_INTERVAL_MS = 1000;
+/** Max polls while waiting for a PENDING job to reach a terminal status. */
+export const RIGOBOT_PUSHER_PENDING_MAX_ATTEMPTS = 3;
 export const BREATHECODE_HOST = "https://breathecode.herokuapp.com";
 
 export const changeSidebarVisibility = () => {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -30,6 +30,8 @@ import {
   getSlugFromPath,
   ensureMinDuration,
   resolveCourseTitle,
+  isWebStudentEnvironment,
+  isWebTelemetryEnvironment,
   // getMainIndex,
 } from "./lib";
 import {
@@ -557,7 +559,7 @@ const useStore = create<IStore>((set, get) => ({
         score: 100,
       });
 
-      if (environment === "localStorage") {
+      if (isWebTelemetryEnvironment(environment)) {
         registerTelemetryEvent("test", data.result);
       }
 
@@ -573,7 +575,7 @@ const useStore = create<IStore>((set, get) => ({
       playEffect("success");
       Notifier.confetti();
 
-      if (environment === "localStorage" || environment === "creatorWeb") {
+      if (isWebTelemetryEnvironment(environment)) {
         const currentExercise = getCurrentExercise();
         TelemetryManager.registerTesteableElement(Number(currentExercise.position), {
           hash: currentExercise.slug,
@@ -598,7 +600,7 @@ const useStore = create<IStore>((set, get) => ({
         type: "code",
         score: 0,
       });
-      if (environment === "localStorage") {
+      if (isWebTelemetryEnvironment(environment)) {
         registerTelemetryEvent("test", data.result);
       }
       if (data.ai_required) {
@@ -612,7 +614,7 @@ const useStore = create<IStore>((set, get) => ({
       }
       playEffect("error");
 
-      if (environment === "localStorage" || environment === "creatorWeb") {
+      if (isWebTelemetryEnvironment(environment)) {
         const currentExercise = getCurrentExercise();
         TelemetryManager.registerTesteableElement(
           Number(currentExercise.position),
@@ -637,7 +639,7 @@ const useStore = create<IStore>((set, get) => ({
       setBuildButtonPrompt("try-again", "bg-fail text-white");
 
       toastFromStatus("compiler-error");
-      if (environment === "localStorage") {
+      if (isWebTelemetryEnvironment(environment)) {
         registerTelemetryEvent("compile", data);
       }
       if (data.ai_required) {
@@ -656,7 +658,7 @@ const useStore = create<IStore>((set, get) => ({
       toastFromStatus("compiler-success");
 
       setBuildButtonPrompt("see-terminal-output", "bg-success text-white");
-      if (environment === "localStorage") {
+      if (isWebTelemetryEnvironment(environment)) {
         registerTelemetryEvent("compile", data);
       }
       if (data.ai_required) {
@@ -1214,9 +1216,7 @@ The user's set up the application in "${language}" language, give your feedback 
       hasSolution: hasSolution,
     });
 
-    const isWebEnv =
-      environment === "localStorage" || environment === "creatorWeb";
-    if (isTesteable && isWebEnv && !TelemetryManager.hasTesteableElementByHash(index, slug)) {
+    if (isTesteable && isWebTelemetryEnvironment(environment) && !TelemetryManager.hasTesteableElementByHash(index, slug)) {
       TelemetryManager.registerTesteableElement(index, {
         hash: slug,
         searchString: slug,
@@ -1604,7 +1604,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
       if (
         editorTabsCopy.length > 0 &&
-        (environment === "localStorage" || environment === "creatorWeb")
+        isWebTelemetryEnvironment(environment)
       ) {
         set({ isTesteable: true, isBuildable: true });
       }
@@ -2079,10 +2079,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
     copy[pos].done = status === "successful";
 
-    const isWebStudent =
-      environment === "localStorage" ||
-      environment === "scorm" ||
-      (environment === "creatorWeb" && mode !== "creator");
+    const isWebStudent = isWebStudentEnvironment(environment, mode);
 
     if (status === "successful" && isWebStudent) {
       const MAX_FILE_SIZE = 50 * 1024;
@@ -2136,6 +2133,7 @@ The user's set up the application in "${language}" language, give your feedback 
       bc_token,
       toastFromStatus,
       reportEnrichDataLayer,
+      mode,
     } = get();
 
     if (!Boolean(bc_token) || !Boolean(token)) {
@@ -2144,7 +2142,7 @@ The user's set up the application in "${language}" language, give your feedback 
     }
 
     if (
-      (environment === "localStorage" || environment === "creatorWeb") &&
+      isWebStudentEnvironment(environment, mode) &&
       !(
         userConsumables.ai_compilation > 0 ||
         userConsumables.ai_compilation === -1
@@ -2203,6 +2201,7 @@ The user's set up the application in "${language}" language, give your feedback 
       environment,
       userConsumables,
       currentContent,
+      mode,
     } = get();
 
     console.log("tokens runnin tests", token, bc_token);
@@ -2212,7 +2211,7 @@ The user's set up the application in "${language}" language, give your feedback 
     }
 
     if (
-      environment === "localStorage" &&
+      isWebStudentEnvironment(environment, mode) &&
       !(
         userConsumables.ai_compilation > 0 ||
         userConsumables.ai_compilation === -1
@@ -2634,10 +2633,7 @@ The user's set up the application in "${language}" language, give your feedback 
     compilerSocket.emit("reset", data);
     reportEnrichDataLayer("learnpack_reset", {});
 
-    const isWebStudent =
-      environment === "localStorage" ||
-      environment === "scorm" ||
-      (environment === "creatorWeb" && mode !== "creator");
+    const isWebStudent = isWebStudentEnvironment(environment, mode);
     if (isWebStudent) {
       const exercise = newExercises.find((e) => e.slug === exerciseSlug);
       if (exercise) {
@@ -2675,10 +2671,7 @@ The user's set up the application in "${language}" language, give your feedback 
     set({ exercises: copy });
     updateDBSession();
 
-    const isWebStudent =
-      environment === "localStorage" ||
-      environment === "scorm" ||
-      (environment === "creatorWeb" && mode !== "creator");
+    const isWebStudent = isWebStudentEnvironment(environment, mode);
     if (isWebStudent) {
       TelemetryManager.registerTesteableElement(Number(exercise.position), {
         hash: exercise.slug,
@@ -3555,27 +3548,22 @@ The user's set up the application in "${language}" language, give your feedback 
     });
   },
   initRigoAI: () => {
-    const { token, environment } = get();
+    const { token, environment, mode } = get();
 
     if (!token) {
       console.log("ERROR: No token found, initializing RigoAI failed");
       return;
     }
 
-    let purposeSlug = "learnpack-lesson-writer";
-
-    if (environment === "creatorWeb") {
-      purposeSlug = "learnpack-lesson-writer";
-    }
-    if (environment === "localStorage") {
-      purposeSlug = "learnpack-ai-tutor";
-    }
+    const purposeSlug = isWebStudentEnvironment(environment, mode)
+      ? "learnpack-ai-tutor"
+      : "learnpack-lesson-writer";
 
     console.log("Initializing RigoAI with purpose slug", purposeSlug);
 
     RigoAI.init({
       chatHash: "529ca5a219084bc7b93c172ad78ef92a",
-      purposeSlug: "learnpack-lesson-writer",
+      purposeSlug,
       userToken: token,
       context:
         "You are a helpful teacher assistant. Please provide your responses always in MARKDOWN. ",

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -2081,6 +2081,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
     const isWebStudent =
       environment === "localStorage" ||
+      environment === "scorm" ||
       (environment === "creatorWeb" && mode !== "creator");
 
     if (status === "successful" && isWebStudent) {
@@ -2635,6 +2636,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
     const isWebStudent =
       environment === "localStorage" ||
+      environment === "scorm" ||
       (environment === "creatorWeb" && mode !== "creator");
     if (isWebStudent) {
       const exercise = newExercises.find((e) => e.slug === exerciseSlug);
@@ -2675,6 +2677,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
     const isWebStudent =
       environment === "localStorage" ||
+      environment === "scorm" ||
       (environment === "creatorWeb" && mode !== "creator");
     if (isWebStudent) {
       TelemetryManager.registerTesteableElement(Number(exercise.position), {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -337,6 +337,7 @@ const useStore = create<IStore>((set, get) => ({
   },
   isCompiling: false,
   compilationWatchdog: null as ReturnType<typeof setTimeout> | null,
+  evaluationRescue: null as (() => Promise<boolean>) | null,
   serviceError: false,
   showSidebar: false,
   user_id: null,
@@ -542,6 +543,7 @@ const useStore = create<IStore>((set, get) => ({
 
     const debounceTestingSuccess = debounce((data: any) => {
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
       const stdout = removeSpecialCharacters(data.logs[0]);
 
       setTestResult("successful", stdout);
@@ -584,6 +586,7 @@ const useStore = create<IStore>((set, get) => ({
 
     const debounceTestingError = debounce((data: any) => {
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
       const stdout = removeSpecialCharacters(data.logs[0]);
       set({ isCompiling: false, serviceError: false });
       setTestResult("failed", stdout);
@@ -626,6 +629,7 @@ const useStore = create<IStore>((set, get) => ({
     let compilerErrorHandler = debounce(async (data: any) => {
       data;
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
 
       set({ lastState: "error", terminalShouldShow: true });
       set({ isCompiling: false, serviceError: false });
@@ -645,6 +649,7 @@ const useStore = create<IStore>((set, get) => ({
     let compilerSuccessHandler = debounce(async (data: any) => {
       data;
       get().clearCompilationWatchdog();
+      set({ evaluationRescue: null });
       set({ lastState: "success", terminalShouldShow: true });
       set({ isCompiling: false, serviceError: false });
 
@@ -744,7 +749,13 @@ const useStore = create<IStore>((set, get) => ({
 
   startCompilationWatchdog: () => {
     get().clearCompilationWatchdog();
-    const id = setTimeout(() => {
+    const id = setTimeout(async () => {
+      if (!get().isCompiling) return;
+      const rescue = get().evaluationRescue;
+      if (rescue) {
+        const rescued = await rescue();
+        if (rescued) return;
+      }
       if (get().isCompiling) get().failCompilation();
     }, RIGOBOT_EVALUATION_TIMEOUT_MS);
     set({ compilationWatchdog: id });
@@ -756,6 +767,10 @@ const useStore = create<IStore>((set, get) => ({
     set({ compilationWatchdog: null });
   },
 
+  setEvaluationRescue: (fn) => {
+    set({ evaluationRescue: fn });
+  },
+
   failCompilation: () => {
     const {
       setFeedbackButtonProps,
@@ -765,7 +780,12 @@ const useStore = create<IStore>((set, get) => ({
       clearCompilationWatchdog,
     } = get();
     clearCompilationWatchdog();
-    set({ isCompiling: false, lastState: "error", serviceError: true });
+    set({
+      isCompiling: false,
+      lastState: "error",
+      serviceError: true,
+      evaluationRescue: null,
+    });
     if (targetButtonForFeedback === "feedback") {
       setFeedbackButtonProps("retry", "bg-fail text-white");
     } else {

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -1,4 +1,5 @@
 import { TStep, TStepEvent } from "../managers/telemetry";
+import { TEnvironment } from "../managers/EventProxy";
 
 /**
  * Tracks the progress of the initial telemetry GET at boot time.
@@ -297,7 +298,7 @@ export interface IStore {
   agent: TAgent;
   learnpackPurposeId: number | string;
   status: string;
-  environment: "localhost" | "localStorage" | "creatorWeb";
+  environment: TEnvironment;
   testingEnvironment: "auto" | "cloud" | "local";
   dialogData: TDialog;
   lessonTitle: string;

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -348,6 +348,8 @@ export interface IStore {
   rigoContext: TRigoContext;
   isCompiling: boolean;
   compilationWatchdog: ReturnType<typeof setTimeout> | null;
+  /** HTTP rescue invoked by the watchdog when Pusher may have failed to deliver. */
+  evaluationRescue: (() => Promise<boolean>) | null;
   /** True only when the last run failed due to a service/infrastructure error (e.g. Rigobot 503), not the student's code. */
   serviceError: boolean;
   showSidebar: boolean;
@@ -407,6 +409,7 @@ export interface IStore {
   setFeedbackButtonProps: (t: string, c: string) => void;
   startCompilationWatchdog: () => void;
   clearCompilationWatchdog: () => void;
+  setEvaluationRescue: (fn: (() => Promise<boolean>) | null) => void;
   failCompilation: () => void;
   fetchSingleExerciseInfo: (index: number) => Promise<TExercise>;
   toggleFeedback: () => void;


### PR DESCRIPTION
## Problemas que resuelve

En entorno SCORM no se registraban los testeable_elements, los consumibles de IA no se validaban y Rigobot usaba un purpose slug incorrecto.

## Soluciones implementadas

- **`lib.tsx`**: nuevos helpers `isWebStudentEnvironment` e `isWebTelemetryEnvironment` que centralizan la detección de entornos en un único lugar.
- **`store.tsx`**: SCORM incluido en registro de testeables al cargar el step  (evita el auto-completado erróneo), eventos `test`/`compile` en telemetría,  consumibles IA en `build` y `runExerciseTests`, y purpose `learnpack-ai-tutor`  en `initRigoAI` (corrige hardcode previo).
- **`fetchManager.ts`**: sesión persistida en SCORM al hacer login con `?token=`.
- **`Editor.tsx`**: banner de readonly migrado al helper compartido.