### PR TITLE
fix(telemetry): registrar correctamente el test element en ejercicios de código

### DIFF
--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1256,26 +1256,12 @@ const TelemetryManager: ITelemetryManager = {
     const step = this.current.steps[stepPosition];
     if (!step || step.completed_at) return;
 
-    // If the step is not a code-test step and none of its persisted
-    // quiz elements appear in activeHashes (no quiz component mounted
-    // during the debounce window), the content no longer exists. Prune
-    // those orphaned elements so the read-only path can proceed.
-    if (!step.is_testeable && step.testeable_elements?.length) {
-      const hasActiveHash = step.testeable_elements.some((e) => {
-        for (const [, hashes] of this.activeHashes) {
-          if (hashes.has(e.hash)) return true;
-        }
-        return false;
-      });
-
-      if (!hasActiveHash) {
-        step.testeable_elements = [];
-        this.current.steps[stepPosition] = step;
-      }
-    }
-
     // If the step has any testeable_elements at this point (e.g. quiz elements
-    // restored from a previous session), it is NOT read-only.
+    // restored from a previous session, or a registered code-test element), it
+    // is NOT read-only. Orphaned quiz elements are intentionally left in place —
+    // they are ignored by hasPendingTasks via the activeHashes filter, so they
+    // don't block completion, but they must never be pruned here (that would
+    // also wipe "test" elements, which are never tracked in activeHashes).
     if (step.testeable_elements?.length) return;
 
     // If the step has code tests, it is NOT read-only.
@@ -1292,9 +1278,8 @@ const TelemetryManager: ITelemetryManager = {
    * Called (via eventBus "lesson_rendered") after the markdown content has
    * rendered in the browser.  A debounce of 5 seconds gives quiz/FITB/OQ
    * components time to mount and register their testeable_elements.  If
-   * after the debounce the step has no active testeable content (and is not
-   * a code-test step), orphaned persisted elements are cleared and the step
-   * can be auto-completed as read-only.
+   * after the debounce the step still has no testeable_elements and is not
+   * a code-test step, it is genuinely read-only and can be completed.
    *
    * The debounce is cancelled every time a new lesson_rendered fires (e.g.
    * the user navigated to another step), so stale completions are avoided.


### PR DESCRIPTION
## Problema
En los ejercicios de código, el `testeable_element` de tipo `test` no quedaba registrado en el step, por lo que luego de 5 segundos, el step se marcaba como completado (como si fuera de solo lectura).

## Causa
Aunque sí se registraba, un bloque de limpieza de quizzes huérfanas en `completeStepIfReadOnly` lo borraba.

## Solución
Se elimina ese bloque de limpieza. Las quizzes huérfanas se conservan y siguen sin contarse como pending tasks (ya las ignora `hasPendingTasks` vía `activeHashes`), y el elemento `test` deja de borrarse, por lo que persiste correctamente.