### PR TITLE
fix: evitar el salto de scroll al redimensionar textareas automáticamente

### DIFF
--- a/src/components/composites/AutoResizeTextarea/AutoResizeTextarea.tsx
+++ b/src/components/composites/AutoResizeTextarea/AutoResizeTextarea.tsx
@@ -18,10 +18,24 @@ export const AutoResizeTextarea = ({
   const ref = useRef<HTMLTextAreaElement>(null);
 
   const resizeTextarea = () => {
-    if (ref.current) {
-      ref.current.style.height = "auto";
-      ref.current.style.height = `${ref.current.scrollHeight}px`;
+    const textarea = ref.current;
+    if (!textarea) return;
+
+    // Measuring requires collapsing the textarea to its natural height, which
+    // makes the browser scroll the focused caret back into view and drags every
+    // scrollable ancestor with it. Snapshot those offsets and put them back
+    // before the browser paints, so the measurement stays invisible.
+    const scrollers: [Element, number][] = [];
+    for (let node = textarea.parentElement; node; node = node.parentElement) {
+      scrollers.push([node, node.scrollTop]);
     }
+    const windowScrollY = window.scrollY;
+
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+
+    for (const [node, scrollTop] of scrollers) node.scrollTop = scrollTop;
+    window.scrollTo(window.scrollX, windowScrollY);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Problema

Al escribir en un `AutoResizeTextarea`, la página salta hasta el cursor en cada pulsación. El usuario coloca el cursor donde quiere escribir y, al teclear, el contenedor scrollea solo.

## Causa

Para medir su altura natural, `resizeTextarea` colapsa el textarea (`height: auto`, con `rows=1`) y luego lo restaura a `scrollHeight`. Mientras está colapsado y enfocado, el navegador vuelve a traer el cursor a la vista, arrastrando consigo a todos los ancestros scrolleables (en el caso de las lecciones, `.content > section`, que tiene `overflow: auto`).

El salto es proporcional al contenido: en bloques de pocas líneas es de unos pocos píxeles y pasa desapercibido, pero crece con el tamaño del texto.

## Solución

Se guardan los `scrollTop` de los ancestros (y el scroll de la ventana) antes de la medición y se restauran inmediatamente después, antes de que el navegador pinte. La medición deja de ser observable.

Medido en un textarea con 400 líneas dentro de un contenedor scrolleable, simulando una pulsación con el cursor a la mitad:

```
antes del fix: scrollTop 2000 -> 7660  (salto de 5660px)
después:       scrollTop 2000 -> 2000  (sin salto)
```

## Alcance

`AutoResizeTextarea` lo usan `Markdowner`, `OpenQuestion`, `Creator` y `ExercisesList`. El fix aplica a todos por igual; no cambia la API del componente.