### PR TITLE
feat: alternar la lección completa a modo markdown

### DIFF
--- a/src/components/Creator/PublishNavbar.tsx
+++ b/src/components/Creator/PublishNavbar.tsx
@@ -13,6 +13,8 @@ export const PublishNavbar = () => {
   const bctoken = useStore((state) => state.bc_token);
   const mode = useStore((state) => state.mode);
   const setMode = useStore((state) => state.setMode);
+  const markdownEditorEnabled = useStore((state) => state.markdownEditorEnabled);
+  const setMarkdownEditorEnabled = useStore((state) => state.setMarkdownEditorEnabled);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -43,11 +45,20 @@ export const PublishNavbar = () => {
       <div className="flex-x align-center gap-big">
 
         <MiniLessonListener />
+        {mode === "creator" && (
+          <SwitchComponent
+            checked={markdownEditorEnabled}
+            onChange={setMarkdownEditorEnabled}
+            label="Markdown"
+            id="markdown-editor"
+          />
+        )}
         <SwitchComponent checked={mode === "creator"} onChange={(checked) => {
           if (checked) {
             setMode("creator");
           } else {
             setMode("student");
+            setMarkdownEditorEnabled(false);
           }
         }} label={t("edit-mode")} id="edit-mode" />
 

--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, useState } from "react";
 import { Toolbar } from "../Editor/Editor";
 import { Markdowner } from "../Markdowner/Markdowner";
+import { AutoResizeTextarea } from "../AutoResizeTextarea/AutoResizeTextarea";
 import { useTranslation } from "react-i18next";
 import useStore from "../../../utils/store";
 import "./LessonStyles.css";
@@ -222,6 +223,9 @@ const LessonInspector = () => {
 export const LessonRenderer = memo(() => {
   const currentContent = useStore((s) => s.currentContent);
   const editingContent = useStore((s) => s.editingContent);
+  const markdownEditorEnabled = useStore((s) => s.markdownEditorEnabled);
+  const setMarkdownEditorEnabled = useStore((s) => s.setMarkdownEditorEnabled);
+  const replaceInReadme = useStore((s) => s.replaceInReadme);
   const agent = useStore((s) => s.agent);
   const environment = useStore((s) => s.environment);
   const setOpenedModals = useStore((s) => s.setOpenedModals);
@@ -230,6 +234,47 @@ export const LessonRenderer = memo(() => {
   const lastTestResult = useStore((s) => s.lastTestResult);
   const isBuildable = useStore((s) => s.isBuildable);
   const currentExercisePosition = useStore((s) => s.currentExercisePosition);
+  const { t } = useTranslation();
+  const [draftContent, setDraftContent] = useState(currentContent);
+  const [isSaving, setIsSaving] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+  const handleSaveRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    setDraftContent(currentContent);
+    setResetKey((k) => k + 1);
+  }, [currentContent]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    await replaceInReadme(
+      draftContent,
+      { line: 1, column: 1, offset: 0 },
+      { line: 1, column: 1, offset: Number.MAX_SAFE_INTEGER }
+    );
+    setIsSaving(false);
+    setMarkdownEditorEnabled(false);
+  };
+
+  handleSaveRef.current = handleSave;
+
+  useEffect(() => {
+    if (!markdownEditorEnabled) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        handleSaveRef.current();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [markdownEditorEnabled]);
+
+  const handleCancel = () => {
+    setDraftContent(currentContent);
+    setResetKey((k) => k + 1);
+    setMarkdownEditorEnabled(false);
+  };
 
   // Notify telemetry that the lesson content has rendered, so it can
   // determine (after a debounce window) whether the step is read-only.
@@ -246,7 +291,7 @@ export const LessonRenderer = memo(() => {
   };
 
   const onlyContinue = !isBuildable && !isTesteable;
-  const toolbarStateClass = 
+  const toolbarStateClass =
     lastTestResult?.status === "failed"
       ? "error"  // Tests failed - keep toolbar red even if compilation succeeds
       : lastTestResult?.status === "successful" && lastState === "success"
@@ -259,7 +304,33 @@ export const LessonRenderer = memo(() => {
       <LessonInspector />
       <AddVideoButton />
 
-      <Markdowner markdown={editingContent || currentContent} allowCreate={true} />
+      {markdownEditorEnabled ? (
+        <div className="flex-y gap-small">
+          <AutoResizeTextarea
+            key={resetKey}
+            defaultValue={currentContent}
+            onChange={(e) => setDraftContent(e.target.value)}
+            className="w-100"
+            minHeight="400px"
+          />
+          <div className="flex-x gap-small justify-end padding-small">
+            <SimpleButton
+              action={handleCancel}
+              extraClass="padding-small border-gray rounded scale-on-hover"
+              svg={svgs.iconClose}
+              text={t("cancel")}
+            />
+            <SimpleButton
+              action={handleSave}
+              extraClass="padding-small border-gray rounded scale-on-hover"
+              svg={svgs.iconCheck}
+              text={isSaving ? t("loading") : t("save")}
+            />
+          </div>
+        </div>
+      ) : (
+        <Markdowner markdown={editingContent || currentContent} allowCreate={true} />
+      )}
 
       {/* <TestLatex /> */}
       <ContinueButton />

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -3205,6 +3205,8 @@ The user's set up the application in "${language}" language, give your feedback 
   setMode: (mode) => {
     set({ mode });
   },
+  markdownEditorEnabled: false,
+  setMarkdownEditorEnabled: (enabled: boolean) => set({ markdownEditorEnabled: enabled }),
 
   getSidebar: async () => {
     const { token } = get();

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -371,6 +371,8 @@ export interface IStore {
   setPendingTranslations: (translations: TLanguageTranslation[] | ((prev: TLanguageTranslation[]) => TLanguageTranslation[])) => void;
   updateTranslationStatus: (languageCode: string, status: TTranslationStatus, error?: string) => void;
   setMode: (mode: TMode) => void;
+  markdownEditorEnabled: boolean;
+  setMarkdownEditorEnabled: (enabled: boolean) => void;
   addVideoTutorial: (videoTutorial: string) => Promise<void>;
   removeVideoTutorial: () => Promise<void>;
   useConsumable: (consumableSlug: TConsumableSlug) => Promise<boolean>;


### PR DESCRIPTION
## Resumen

En modo creador no había forma de editar el README de una lección como markdown crudo: sólo se podía editar bloque por bloque desde el `Markdowner`. Esto complica los cambios que abarcan varios bloques (reordenar secciones, arreglar una tabla, pegar contenido).

Este PR agrega un toggle **Markdown** en la navbar que cambia la lección completa a un editor de texto plano.

## Cambios

- **`PublishNavbar`**: nuevo toggle `Markdown`, visible sólo en modo creador. Al salir de modo creador se apaga solo, para no dejar el editor abierto en modo estudiante.
- **`LessonRenderer`**: con el toggle activo se renderiza un textarea con el README crudo en lugar del `Markdowner`, con botones de guardar/cancelar y atajo `Ctrl/Cmd+S`.
- **`store`**: nuevo estado `markdownEditorEnabled` con su setter.

El guardado reutiliza `replaceInReadme`, así que el front matter, el historial de versiones y la sincronización de idioma siguen funcionando igual que en la edición por bloques.

## Notas

- Las claves i18n usadas (`save`, `cancel`, `loading`) ya existían en `en`/`es`.
- Relacionado: #112. Sin ese fix, el textarea de esta pantalla scrollea hasta el cursor en cada pulsación (es el caso más visible del bug, porque acá el textarea contiene el README entero).