### PR TITLE
refactor: increase Rigobot evaluation timeout for occasional delays

### DIFF
--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -186,7 +186,7 @@ getEnvironment();
 export const RIGOBOT_HOST = import.meta.env.VITE_RIGOBOT_HOST || "https://rigobot.herokuapp.com";
 // export const RIGOBOT_HOST = "https://8000-charlytoc-rigobot-bmwdeam7cev.ws-us120.gitpod.io";
 /** Max wait for Rigobot evaluation (tests, builds, open questions) before showing Retry. */
-export const RIGOBOT_EVALUATION_TIMEOUT_MS = 20000;
+export const RIGOBOT_EVALUATION_TIMEOUT_MS = 30000;
 /** HTTP rescue poll interval after the evaluation watchdog fires (Pusher may have failed). */
 export const RIGOBOT_RESCUE_POLL_INTERVAL_MS = 2000;
 /** Max HTTP polls during a rescue burst after watchdog timeout. */


### PR DESCRIPTION
- Incrementa el timeout de 20 a 30 segundos
- Entre el 99% y el 95% de las request demoran menos de medio segundo
- Pero en picos ocasionales se registran algunas request de más de 20 segundos, por eso propongo subir de 20 a 30 segundos el timeout en IDE.

<img width="1217" height="581" alt="rigobot-response-time" src="https://github.com/user-attachments/assets/4995d2af-2749-43ce-b5d4-d718f15d49f7" />


<img width="1211" height="568" alt="rigobot-response-time2" src="https://github.com/user-attachments/assets/be244bdf-4d53-4e60-a90a-1a789ade5b9c" />
