### PR TITLE
feat: mostrar el atajo de guardado en el editor markdown

### DIFF
--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -276,6 +276,9 @@ export const LessonRenderer = memo(() => {
     setMarkdownEditorEnabled(false);
   };
 
+  const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  const saveShortcut = isMac ? "⌘S" : "Ctrl+S";
+
   // Notify telemetry that the lesson content has rendered, so it can
   // determine (after a debounce window) whether the step is read-only.
   useEffect(() => {
@@ -324,7 +327,16 @@ export const LessonRenderer = memo(() => {
               action={handleSave}
               extraClass="padding-small border-gray rounded scale-on-hover"
               svg={svgs.iconCheck}
-              text={isSaving ? t("loading") : t("save")}
+              text={
+                isSaving ? (
+                  t("loading")
+                ) : (
+                  <>
+                    {t("save")}
+                    <kbd className="kbd-hint">{saveShortcut}</kbd>
+                  </>
+                )
+              }
             />
           </div>
         </div>

--- a/src/components/composites/LessonRenderer/LessonStyles.css
+++ b/src/components/composites/LessonRenderer/LessonStyles.css
@@ -334,3 +334,16 @@
     color: var(--color-blue-rigo);
   }
 }
+
+.kbd-hint {
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1.4;
+  color: var(--color-gray, #6b7280);
+  background: var(--bg-color, #f3f4f6);
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+  opacity: 0.75;
+}


### PR DESCRIPTION
## Resumen

Complemento de #113. El modo markdown ya soporta guardar con `Ctrl/Cmd+S`, pero no había nada en la interfaz que lo indicara.

Este PR muestra el atajo como un chip siempre visible dentro del botón *Guardar*, adaptado a la plataforma (`⌘S` en Mac, `Ctrl+S` en Windows/Linux), reutilizando la detección de `navigator.platform` que ya usa `HistoryControls`.

## Cambios

- **`LessonRenderer`**: el botón *Guardar* del editor markdown muestra el atajo junto a la etiqueta.
- **`LessonStyles.css`**: estilo `.kbd-hint` para el chip.

Sin cambios de comportamiento: el atajo ya funcionaba, esto sólo lo hace visible.