### PR TITLE
fix: no capturar Ctrl/Cmd+Z cuando el foco está en un campo de texto

### DIFF
--- a/src/components/HistoryControls/HistoryControls.tsx
+++ b/src/components/HistoryControls/HistoryControls.tsx
@@ -37,6 +37,15 @@ export const HistoryControls = () => {
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      // When a text field has focus, let it handle its own undo/redo.
+      // Without this, the listener below preventDefault()s every Ctrl/Cmd+Z in
+      // creator mode, so typing in a block editor could not be undone and a
+      // document-level undo fired instead.
+      // Both `?.` on closest are required: event.target may be Document or
+      // Window, neither of which has closest().
+      const el = event.target as HTMLElement | null;
+      if (el?.isContentEditable || el?.closest?.("input, textarea")) return;
+
       const cmdOrCtrl = isMac ? event.metaKey : event.ctrlKey;
 
       // Ctrl/Cmd + Z = Undo


### PR DESCRIPTION
## Problema

En modo creador, al editar un bloque como markdown y pulsar `Ctrl/Cmd+Z` para
deshacer lo recién escrito, no se deshace el texto: se ejecuta un deshacer a
nivel de documento, que revierte el último cambio guardado del README —
normalmente de otro bloque.

## Causa

`HistoryControls` registra un listener de `keydown` en `window` y llama a
`event.preventDefault()` en todo `Ctrl/Cmd+Z` mientras `mode === "creator"`,
sin mirar qué elemento tiene el foco. Al cancelarse la acción por defecto, el
navegador nunca ejecuta el deshacer nativo del textarea, y en su lugar se
dispara `performUndo()`, que hace un POST a `/history/undo` y reemplaza
`currentContent` entero.

Como el `preventDefault()` ocurre antes de comprobar `canUndo`, el atajo queda
inutilizado incluso cuando no hay historial que deshacer.

## Solución

Salir del handler cuando el foco está en un campo de texto, dejando que el
navegador haga su propio deshacer/rehacer:

```ts
const el = event.target as HTMLElement | null;
if (el?.isContentEditable || el?.closest?.("input, textarea")) return;
```

El deshacer a nivel de documento sigue funcionando cuando el foco está fuera de
un campo editable, y los botones de la barra no cambian.

Verificado en el navegador sobre un curso real:

```
foco en textarea del bloque:  defaultPrevented=false, sin POST /history/undo,
                              texto restaurado (322 -> 307 chars)
foco en body:                 defaultPrevented=true, POST /history/undo disparado
foco en Monaco:               el evento no llega al listener (Monaco hace
                              stopPropagation por su cuenta)
```

## Alcance

- Aplica igual a rehacer (`Ctrl+Y`, `Cmd+Shift+Z`): la comprobación está antes
  de todas las ramas de teclas.
- No afecta al modo estudiante: el listener sólo se registra con
  `mode === "creator"`.
- Monaco ya estaba a salvo por su propio `stopPropagation`; el cambio no lo altera.
- Los dos `?.` de `closest` son necesarios: `event.target` puede ser `Document`
  o `Window`, que no tienen `closest()`.
