### PR TITLE
fix: evitar la pérdida del borrador en el editor markdown

### DIFF
--- a/src/components/Creator/PublishNavbar.tsx
+++ b/src/components/Creator/PublishNavbar.tsx
@@ -15,6 +15,7 @@ export const PublishNavbar = () => {
   const setMode = useStore((state) => state.setMode);
   const markdownEditorEnabled = useStore((state) => state.markdownEditorEnabled);
   const setMarkdownEditorEnabled = useStore((state) => state.setMarkdownEditorEnabled);
+  const requestMarkdownDraftDiscard = useStore((state) => state.requestMarkdownDraftDiscard);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -48,7 +49,15 @@ export const PublishNavbar = () => {
         {mode === "creator" && (
           <SwitchComponent
             checked={markdownEditorEnabled}
-            onChange={setMarkdownEditorEnabled}
+            onChange={(checked) => {
+              // Turning the switch off closes the editor: confirm first if the
+              // draft has unsaved edits.
+              if (!checked) {
+                requestMarkdownDraftDiscard(() => setMarkdownEditorEnabled(false));
+                return;
+              }
+              setMarkdownEditorEnabled(true);
+            }}
             label="Markdown"
             id="markdown-editor"
           />
@@ -56,10 +65,13 @@ export const PublishNavbar = () => {
         <SwitchComponent checked={mode === "creator"} onChange={(checked) => {
           if (checked) {
             setMode("creator");
-          } else {
+            return;
+          }
+          // Leaving creator mode also closes the markdown editor.
+          requestMarkdownDraftDiscard(() => {
             setMode("student");
             setMarkdownEditorEnabled(false);
-          }
+          });
         }} label={t("edit-mode")} id="edit-mode" />
 
         <PublishButton />

--- a/src/components/composites/LessonRenderer/LessonRenderer.tsx
+++ b/src/components/composites/LessonRenderer/LessonRenderer.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import useStore from "../../../utils/store";
 import "./LessonStyles.css";
 import SimpleButton from "../../mockups/SimpleButton";
+import { Modal } from "../../mockups/Modal";
 import { eventBus } from "../../../managers/eventBus";
 import { fixLesson } from "../../../managers/EventProxy";
 import RealtimeNotificationListener from "../../Creator/RealtimeNotificationListener";
@@ -225,6 +226,10 @@ export const LessonRenderer = memo(() => {
   const editingContent = useStore((s) => s.editingContent);
   const markdownEditorEnabled = useStore((s) => s.markdownEditorEnabled);
   const setMarkdownEditorEnabled = useStore((s) => s.setMarkdownEditorEnabled);
+  const markdownDraftDirty = useStore((s) => s.markdownDraftDirty);
+  const setMarkdownDraftDirty = useStore((s) => s.setMarkdownDraftDirty);
+  const pendingDiscard = useStore((s) => s.pendingDiscard);
+  const resolveMarkdownDraftDiscard = useStore((s) => s.resolveMarkdownDraftDiscard);
   const replaceInReadme = useStore((s) => s.replaceInReadme);
   const agent = useStore((s) => s.agent);
   const environment = useStore((s) => s.environment);
@@ -239,21 +244,50 @@ export const LessonRenderer = memo(() => {
   const [isSaving, setIsSaving] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const handleSaveRef = useRef<() => void>(() => {});
+  // Guards against concurrent saves. A ref rather than the isSaving state
+  // because two clicks (or Ctrl+S repeats) landing in the same render pass
+  // would both read a stale `false` from state.
+  const isSavingRef = useRef(false);
 
+  // Follow the saved lesson only while there is nothing unsaved to lose.
+  // currentContent also moves on optimistic saves, failed-save rollbacks,
+  // undo/redo and background syncs; re-seeding then would wipe the buffer the
+  // user is still editing. Clearing the flag (cancel, discard, save) re-runs
+  // this and resynchronises the draft.
   useEffect(() => {
+    if (markdownDraftDirty) return;
     setDraftContent(currentContent);
     setResetKey((k) => k + 1);
-  }, [currentContent]);
+  }, [currentContent, markdownDraftDirty]);
 
-  const handleSave = async () => {
+  // Safety net. This component is mounted for the app's lifetime today, so the
+  // cleanup never runs; it matters only if that ever changes. A flag left set
+  // with no editor to clear it would block navigation behind a modal that is
+  // no longer rendered. The dep is a stable store action.
+  useEffect(() => () => setMarkdownDraftDirty(false), [setMarkdownDraftDirty]);
+
+  const handleSave = async (): Promise<boolean> => {
+    if (isSavingRef.current) return false;
+    isSavingRef.current = true;
     setIsSaving(true);
-    await replaceInReadme(
-      draftContent,
-      { line: 1, column: 1, offset: 0 },
-      { line: 1, column: 1, offset: Number.MAX_SAFE_INTEGER }
-    );
-    setIsSaving(false);
-    setMarkdownEditorEnabled(false);
+    try {
+      const result = await replaceInReadme(
+        draftContent,
+        { line: 1, column: 1, offset: 0 },
+        { line: 1, column: 1, offset: Number.MAX_SAFE_INTEGER }
+      );
+      // Only close on success. On failure the draft stays on screen so the
+      // user can retry; replaceInReadme already reports the error via toast.
+      if (result?.success) {
+        setMarkdownDraftDirty(false);
+        setMarkdownEditorEnabled(false);
+        return true;
+      }
+      return false;
+    } finally {
+      isSavingRef.current = false;
+      setIsSaving(false);
+    }
   };
 
   handleSaveRef.current = handleSave;
@@ -263,16 +297,19 @@ export const LessonRenderer = memo(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "s") {
         e.preventDefault();
+        // Inert while the discard prompt is open: it has its own Save button,
+        // and a shortcut save behind it would leave the prompt out of date.
+        if (pendingDiscard) return;
         handleSaveRef.current();
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [markdownEditorEnabled]);
+  }, [markdownEditorEnabled, pendingDiscard]);
 
   const handleCancel = () => {
-    setDraftContent(currentContent);
-    setResetKey((k) => k + 1);
+    // Clearing the flag lets the effect above resynchronise the draft.
+    setMarkdownDraftDirty(false);
     setMarkdownEditorEnabled(false);
   };
 
@@ -311,20 +348,25 @@ export const LessonRenderer = memo(() => {
         <div className="flex-y gap-small">
           <AutoResizeTextarea
             key={resetKey}
-            defaultValue={currentContent}
-            onChange={(e) => setDraftContent(e.target.value)}
+            defaultValue={draftContent}
+            onChange={(e) => {
+              setDraftContent(e.target.value);
+              setMarkdownDraftDirty(true);
+            }}
             className="w-100"
             minHeight="400px"
           />
           <div className="flex-x gap-small justify-end padding-small">
             <SimpleButton
               action={handleCancel}
+              disabled={isSaving || !!pendingDiscard}
               extraClass="padding-small border-gray rounded scale-on-hover"
               svg={svgs.iconClose}
               text={t("cancel")}
             />
             <SimpleButton
               action={handleSave}
+              disabled={isSaving || !!pendingDiscard}
               extraClass="padding-small border-gray rounded scale-on-hover"
               svg={svgs.iconCheck}
               text={
@@ -342,6 +384,40 @@ export const LessonRenderer = memo(() => {
         </div>
       ) : (
         <Markdowner markdown={editingContent || currentContent} allowCreate={true} />
+      )}
+
+      {/* The Modal's own X (and clicking outside) resolves as "keep editing". */}
+      {pendingDiscard && (
+        <Modal
+          extraClass="unsaved-draft-modal"
+          outsideClickHandler={() => resolveMarkdownDraftDiscard(false)}
+        >
+          <div className="draft-warning flex-x align-center">
+            <div className="big-svg">{svgs.rigoSoftBlue}</div>
+            <p>{t("unsaved-changes-description")}</p>
+          </div>
+          <div className="flex-x gap-small justify-center">
+            <SimpleButton
+              text={isSaving ? t("loading") : t("save")}
+              svg={svgs.iconCheck}
+              disabled={isSaving}
+              extraClass="padding-small bg-blue-rigo text-white rounded"
+              action={async () => {
+                // On success the parked action continues; on failure the
+                // editor stays open with the draft and the caller is unwound
+                // (the error toast already explains what happened).
+                resolveMarkdownDraftDiscard(await handleSave());
+              }}
+            />
+            <SimpleButton
+              text={t("discardElement")}
+              svg={svgs.trash}
+              disabled={isSaving}
+              extraClass="padding-small border-gray rounded"
+              action={() => resolveMarkdownDraftDiscard(true)}
+            />
+          </div>
+        </Modal>
       )}
 
       {/* <TestLatex /> */}

--- a/src/components/composites/LessonRenderer/LessonStyles.css
+++ b/src/components/composites/LessonRenderer/LessonStyles.css
@@ -347,3 +347,28 @@
   border-radius: 4px;
   opacity: 0.75;
 }
+
+/* Unsaved-draft confirmation dialog. The Modal's close X is absolutely
+   positioned in the band a title normally occupies, so push the body below it
+   and give the actions room to breathe. pre-line honours the line break
+   encoded in the translation. */
+/* Selector mirrors the Modal's own width rule so it out-specifies it. */
+.self-closing-modal > div.modal-content.unsaved-draft-modal {
+  /* Size the dialog to its content instead of the Modal's fixed 600px. */
+  width: fit-content;
+  max-width: 98vw;
+}
+.unsaved-draft-modal .draft-warning {
+  /* 49px top puts 24px of air below the close X — same as above the buttons. */
+  margin: 49px 0 24px;
+  gap: 18px;
+}
+.unsaved-draft-modal p {
+  margin: 0;
+  white-space: pre-line;
+}
+.unsaved-draft-modal .simple-button-svg {
+  padding: 6px 18px;
+  /* Tighter than the global 10px so icon and label read as one unit. */
+  gap: 6px;
+}

--- a/src/components/composites/PositionHandler/PositionHandler.tsx
+++ b/src/components/composites/PositionHandler/PositionHandler.tsx
@@ -46,6 +46,7 @@ const ValidationModal = ({
 
 export const PositionHandler = () => {
   const handlePositionChange = useStore((s) => s.handlePositionChange);
+  const requestMarkdownDraftDiscard = useStore((s) => s.requestMarkdownDraftDiscard);
   const mode = useStore((s) => s.mode);
 
   const currentExercisePosition = useStore((s) => s.currentExercisePosition);
@@ -70,16 +71,25 @@ export const PositionHandler = () => {
   }, [mode]);
 
   const handler = () => {
-    const result = TelemetryManager.hasPendingTasks(
-      Number(currentExercisePositionRef.current)
+    // Changing lesson swaps the content out from under the markdown editor and
+    // silently drops the draft, so confirm before letting navigation proceed.
+    requestMarkdownDraftDiscard(
+      () => {
+        const result = TelemetryManager.hasPendingTasks(
+          Number(currentExercisePositionRef.current)
+        );
+        if (result && currentModeRef.current !== "creator") {
+          setShouldValidate(true);
+          return;
+        } else {
+          handlePositionChange(desiredPosition.current);
+          eventBus.emit("position_changed", {});
+        }
+      },
+      // Staying put still ends the attempt: the Continue button shows a loader
+      // until this fires. Mirrors ValidationModal's "stay here" below.
+      () => eventBus.emit("position_changed", {})
     );
-    if (result && currentModeRef.current !== "creator") {
-      setShouldValidate(true);
-      return;
-    } else {
-      handlePositionChange(desiredPosition.current);
-      eventBus.emit("position_changed", {});
-    }
   };
 
   return (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -419,6 +419,7 @@
     "video-tutorial-removed": "Video tutorial removed!",
     "pending-tasks": "Pending tasks",
     "pending-tasks-description": "You have unfinished tasks to validate. We encourage you to complete them before continuing.",
+    "unsaved-changes-description": "You have unsaved changes in the markdown editor.\nSave or discard them, or press X to keep editing.",
     "stay-here": "Stay here",
     "skip-and-continue": "Skip and continue",
     "loading": "Loading...",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -427,6 +427,7 @@
     "video-tutorial-added": "¡Video tutorial agregado!",
     "pending-tasks": "Tareas pendientes",
     "pending-tasks-description": "Tienes tareas pendientes para validar. Te animamos a completarlas antes de continuar.",
+    "unsaved-changes-description": "Tienes cambios sin guardar en el editor markdown.\nGuárdalos o descártalos, o pulsa X para seguir editando.",
     "stay-here": "Quedarse aquí",
     "skip-and-continue": "Saltar y continuar",
     "loading": "Cargando...",

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -3208,6 +3208,43 @@ The user's set up the application in "${language}" language, give your feedback 
   markdownEditorEnabled: false,
   setMarkdownEditorEnabled: (enabled: boolean) => set({ markdownEditorEnabled: enabled }),
 
+  markdownDraftDirty: false,
+  setMarkdownDraftDirty: (dirty: boolean) => set({ markdownDraftDirty: dirty }),
+
+  pendingDiscard: null,
+
+  // Run `confirm` straight away unless the markdown draft has unsaved edits, in
+  // which case park it and let the confirmation modal decide its fate. Callers
+  // stay synchronous and do not need to know whether a prompt was shown; those
+  // that leave state pending pass `cancel` to unwind it.
+  requestMarkdownDraftDiscard: (confirm: () => void, cancel?: () => void) => {
+    const { markdownDraftDirty, pendingDiscard } = get();
+    if (!markdownDraftDirty) {
+      confirm();
+    } else if (pendingDiscard) {
+      // A prompt is already open (the modal does not trap focus, so a second
+      // exit can still be triggered). Unwind the newcomer rather than clobber
+      // the parked one, whose caller may be waiting on its cancel.
+      cancel?.();
+    } else {
+      set({ pendingDiscard: { confirm, cancel } });
+    }
+  },
+
+  resolveMarkdownDraftDiscard: (confirmed: boolean) => {
+    const pending = get().pendingDiscard;
+    set({ pendingDiscard: null });
+    if (!pending) return;
+    if (confirmed) {
+      // Clear before running: it both stops the next exit attempt prompting
+      // again and lets the editor resynchronise its draft from the lesson.
+      set({ markdownDraftDirty: false });
+      pending.confirm();
+    } else {
+      pending.cancel?.();
+    }
+  },
+
   getSidebar: async () => {
     const { token } = get();
     const sidebar = await FetchManager.getSidebar(token);

--- a/src/utils/storeTypes.ts
+++ b/src/utils/storeTypes.ts
@@ -373,6 +373,13 @@ export interface IStore {
   setMode: (mode: TMode) => void;
   markdownEditorEnabled: boolean;
   setMarkdownEditorEnabled: (enabled: boolean) => void;
+  markdownDraftDirty: boolean;
+  setMarkdownDraftDirty: (dirty: boolean) => void;
+  // Outcome parked while the user is asked to confirm discarding a dirty
+  // markdown draft. Non-null means the confirmation modal is showing.
+  pendingDiscard: { confirm: () => void; cancel?: () => void } | null;
+  requestMarkdownDraftDiscard: (confirm: () => void, cancel?: () => void) => void;
+  resolveMarkdownDraftDiscard: (confirmed: boolean) => void;
   addVideoTutorial: (videoTutorial: string) => Promise<void>;
   removeVideoTutorial: () => Promise<void>;
   useConsumable: (consumableSlug: TConsumableSlug) => Promise<boolean>;


### PR DESCRIPTION
## Problema

Cierra learnpack/learnpack#2094. El modo markdown (#113) puede perder el trabajo del autor de tres formas:

1. **Guardado fallido.** `handleSave` siempre cerraba el editor, aunque `replaceInReadme` devolviera `{ success: false }`. Y aunque se dejara abierto, el borrador se perdía igual (ver Causa).
2. **Guardados duplicados.** Nada impedía dos `replaceInReadme` concurrentes por doble clic o `Ctrl+S` repetido, compitiendo por `historyVersion`.
3. **Descarte silencioso.** Apagar el toggle Markdown, salir del modo creador o cambiar de lección descartaba las ediciones sin avisar.

## Causa

El punto 1 es más profundo de lo que sugiere el issue: el textarea deriva su contenido de `currentContent` (`defaultValue={currentContent}`, más un efecto de `AutoResizeTextarea` que escribe `ref.current.value` cuando cambia). Cualquier movimiento de `currentContent` con el editor abierto sobreescribe lo que el usuario está escribiendo:

- el rollback de un guardado fallido (el caso reportado),
- los botones Deshacer/Rehacer de la navbar (verificado: destruyen el borrador abierto),
- cualquier recarga de fondo (`fetchReadme`, sync, arreglos de Rigobot).

El atajo `Ctrl/Cmd+Z` dentro del textarea quedó cubierto por #116; los botones no.

## Solución

Un solo estado nuevo, `markdownDraftDirty`, gobierna todo:

- El re-seed del borrador desde `currentContent` sólo ocurre cuando no hay ediciones sin guardar, y el textarea pasa a `defaultValue={draftContent}`: mientras se edita, el buffer pertenece al usuario. Asignar un string idéntico a `.value` no mueve el cursor (verificado, también escribiendo rápido a mitad del documento).
- `handleSave` sólo cierra el editor con `success === true`, los botones Guardar/Cancelar se deshabilitan durante el guardado, y un guard de reentrada por ref cubre lo que el `disabled` no puede: React no re-renderiza entre dos clics del mismo tick (verificado: el segundo clic llega con el botón aún habilitado).
- Los tres puntos de salida (toggle Markdown, toggle modo edición, cambio de lección) pasan por `requestMarkdownDraftDiscard`, que ejecuta la acción directamente si no hay nada que perder, o abre un diálogo de confirmación si lo hay. El diálogo ofrece **Guardar** (guarda y, si el guardado tuvo éxito, la acción interrumpida continúa; si falla, el borrador y el editor se conservan y la acción no continúa) y **Descartar** (descarta y continúa); la **X** del modal — o clicar fuera — cierra el diálogo y se sigue editando.
- El handshake guarda `{ confirm, cancel }` en el store: quedarse editando tras un cambio de lección emite `position_changed` para liberar el botón *Continuar* (mismo patrón que el «quedarse aquí» de `ValidationModal`). Una petición ya parqueada no se sobreescribe; la nueva se desactiva sola.
- Mientras el diálogo está abierto, el `Ctrl+S` y los botones Guardar/Cancelar del editor quedan inertes (el diálogo tiene su propio Guardar; el modal no atrapa el foco, así que seguían alcanzables por teclado).

Verificado en el navegador sobre un curso real:

```
guardado fallido (PUT 500):        editor abierto, borrador intacto
undo con borrador sucio:           POST /history/undo disparado, borrador intacto
3 clics / 5x Ctrl+S:               exactamente 1 PUT
guardar desde el diálogo:          1 PUT y la acción interrumpida continúa
guardar desde el diálogo (500):    la acción no continúa; borrador intacto
cambio de lección sin ediciones:   sin diálogo, el borrador sigue a la lección nueva
descartar y navegar:               el borrador se re-siembra con la lección nueva
descartar, reabrir y guardar:      el borrador descartado no se filtra al PUT
X tras pulsar Continuar:           el botón vuelve de «Cargando…» a «Continuar»
salir de modo creador:             diálogo; al descartar, vista estudiante limpia
```

## Alcance

- Todo lo nuevo está detrás de `markdownDraftDirty`, que sólo puede activarse escribiendo en el editor markdown en modo creador. Para modo estudiante y VSCode el único camino compartido (`PositionHandler`) es un pass-through síncrono, idéntico al comportamiento actual.
- El diálogo reutiliza `Modal`, `SimpleButton` y claves i18n existentes (`save`, `discardElement`); sólo se añade una clave nueva (`unsaved-changes-description`) en `en`/`es`. Sus estilos van scoped bajo `.unsaved-draft-modal` en `LessonStyles.css`.
- Relacionado: #113 (introduce el modo markdown), #115 (el chip del atajo convive con el `disabled` nuevo), #116 (cubre el atajo de teclado; este PR cubre los botones de la navbar).
