### PR TITLE
fix: no tratar el texto entre dos símbolos $ como fórmula matemática

### DIFF
--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -1,4 +1,5 @@
 import Markdown, { type Components } from "react-markdown";
+import { type PluggableList } from "unified";
 import { Element } from "hast";
 import remarkGfm from "remark-gfm";
 import { TMetadata } from "./types";
@@ -181,7 +182,15 @@ const generateHeadingID = (md: string) => {
   return md.toLowerCase().replace(/ /g, "-").replace(/[^a-z0-9-]/g, "");
 }
 
-const REMARK_PLUGINS = [remarkGfm, remarkMath, emoji];
+// singleDollarTextMath is disabled so a lone "$" is treated as literal text:
+// with it enabled, prose containing two dollar signs (e.g. "$300,000 ... $310,000"
+// or two n8n "{{ $json.x }}" expressions) gets the span between them swallowed
+// and typeset as a KaTeX formula. Math still renders via $$...$$ (inline or block).
+const REMARK_PLUGINS: PluggableList = [
+  remarkGfm,
+  [remarkMath, { singleDollarTextMath: false }],
+  emoji,
+];
 const REHYPE_PLUGINS = [rehypeKatex];
 
 export const Markdowner = ({


### PR DESCRIPTION
Fixes learnpack/learnpack#2089

## Problema

Cuando un párrafo contiene dos cifras en dólares, el texto entre ambas se renderiza como fórmula matemática:

```
"…the true house price is $300,000, a prediction of $310,000 is not…"
```

se muestra como `300,000, apredictionof 310,000` — letras en cursiva, espacios colapsados.

No afecta sólo a cifras monetarias: cualquier lección con dos `$` en un mismo párrafo fuera de un bloque de código lo sufre, p. ej. las expresiones de n8n (`{{ $json.task }} … {{ $json.due }}`).

## Causa

`Markdowner` registra `remark-math` sin opciones, y su valor por defecto `singleDollarTextMath: true` hace que un solo `$` abra TeX en línea hasta el siguiente `$`, sin reglas de contexto (admite prosa, comas y espacios). El fragmento intermedio se convierte en un nodo `inlineMath` que `rehype-katex` tipografía como fórmula:

```
texto:      "…the true house price is "
inlineMath: "300,000, a prediction of "   ← tipografiado por KaTeX
texto:      "310,000 is not…"
```

Además alimenta el bucle de autocorrección de `LessonInspector`: cuando el fragmento capturado produce un `katex-error`, `fixLesson` "repara" la lección reescribiendo contenido real como LaTeX — encontramos un `&&` convertido en `\text{ and }` dentro de una expresión de n8n — corrompiendo el fuente del curso de forma permanente.

## Solución

Desactivar `singleDollarTextMath` en el único punto donde se configura `remark-math`:

```ts
const REMARK_PLUGINS: PluggableList = [
  remarkGfm,
  [remarkMath, { singleDollarTextMath: false }],
  emoji,
];
```

Un `$` suelto pasa a ser texto literal. Las fórmulas siguen renderizando con `$$...$$`, tanto en línea (`$$E = mc^2$$`) como en bloque, y `\$` escapado funciona igual que antes.

Verificado con `tsc --noEmit` y parseando la frase exacta del issue por el mismo pipeline antes/después del cambio:

```
antes:   $300,000 … $310,000           → inlineMath "300,000, a prediction of "
después: $300,000 … $310,000           → texto literal, sin nodos de fórmula
         {{ $json.a }} … {{ $json.b }} → texto literal
         $$E = mc^2$$ (en línea)       → inlineMath ✓
         $$…$$ (bloque)                → math ✓
```

## Alcance

- Único cambio de comportamiento: las fórmulas delimitadas con un solo `$` (`$E = mc^2$`) dejan de renderizar como matemática. Una revisión del contenido de cursos existente no encontró ninguna lección que dependa de ello — las que usan fórmulas usan `$$` o ninguna.
- Afecta a todas las superficies de renderizado (lección, vista previa del creador, diffs), ya que todas pasan por `Markdowner`.
- El CLI hereda la corrección en la siguiente publicación del bundle; no requiere cambios propios.
