### PR TITLE
fix: renderiza etiquetas HTML inline como código en lugar de eliminarlas

### DIFF
--- a/src/components/composites/Markdowner/Markdowner.tsx
+++ b/src/components/composites/Markdowner/Markdowner.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import { TMetadata } from "./types";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
+import { remarkInlineHtmlToCode } from "./remarkInlineHtmlToCode";
 import useStore from "../../../utils/store";
 import { useShallow } from "zustand/react/shallow";
 import emoji from "remark-emoji";
@@ -190,6 +191,7 @@ const REMARK_PLUGINS: PluggableList = [
   remarkGfm,
   [remarkMath, { singleDollarTextMath: false }],
   emoji,
+  remarkInlineHtmlToCode,
 ];
 const REHYPE_PLUGINS = [rehypeKatex];
 

--- a/src/components/composites/Markdowner/remarkInlineHtmlToCode.ts
+++ b/src/components/composites/Markdowner/remarkInlineHtmlToCode.ts
@@ -1,0 +1,36 @@
+import type { InlineCode, Parent, Root } from "mdast";
+
+// Rigobot sometimes generates lesson text where an HTML tag mentioned in prose
+// is not wrapped in backticks (e.g. "## The <form> Tag"). The markdown parser
+// tokenizes the bare tag as raw inline HTML and react-markdown's skipHtml then
+// deletes it, so the heading renders as "The  Tag" (learnpack/learnpack#1933).
+//
+// This plugin converts inline raw-HTML nodes into inlineCode, so the tag
+// renders exactly as if the author had written `<form>`. Block-level HTML
+// (intentional layout markup such as <details> wrappers or spacer divs) and
+// HTML comments (<!-- hide -->) are left untouched: skipHtml keeps dropping
+// them, exactly as before.
+const transformChildren = (parent: Parent) => {
+  parent.children.forEach((child, index) => {
+    if (
+      child.type === "html" &&
+      parent.type !== "root" &&
+      !child.value.trimStart().startsWith("<!--")
+    ) {
+      // position carried over so position-based features (creator editing,
+      // getPortion) still see the original offsets.
+      const replacement: InlineCode = {
+        type: "inlineCode",
+        value: child.value,
+        position: child.position,
+      };
+      parent.children[index] = replacement;
+    } else if ("children" in child) {
+      transformChildren(child);
+    }
+  });
+};
+
+export const remarkInlineHtmlToCode = () => (tree: Root) => {
+  transformChildren(tree);
+};


### PR DESCRIPTION
Fixes learnpack/learnpack#1933

## Problema

Cuando una lección menciona una etiqueta HTML sin backticks (típico en texto generado por Rigobot), la etiqueta desaparece: `## The <form> Tag` se renderiza como "The Tag".

## Causa

El parser tokeniza la etiqueta suelta como HTML crudo y el `skipHtml={true}` de `Markdowner` elimina el nodo del árbol. Quitar `skipHtml` no sirve: mostraría como texto plano el HTML intencional de bloque (`<details>`, `<!-- hide -->`, etc.) que sí existe en cursos publicados.

## Solución

Un plugin remark autocontenido convierte los nodos HTML inline (no comentarios) en `inlineCode`, igual que si el autor hubiera escrito `` `<form>` ``. El HTML de bloque y los comentarios se siguen descartando como hasta ahora.

```
antes:   <h2>The  Tag</h2>
después: <h2>The <code>&lt;form&gt;</code> Tag</h2>
```

## Alcance

Verificado contra más de 3500 lecciones de cursos publicados (incluyendo varios cursos legacy de 4Geeks): cada nodo HTML inline encontrado es instancia de este bug y ningún HTML intencional cambia de comportamiento. Sin dependencias nuevas; tsc y eslint sin errores nuevos.
