### PR TITLE
fix: reflejar el estado real de generación en el menú lateral

### DIFF
--- a/src/components/Creator/MiniLessonListener.tsx
+++ b/src/components/Creator/MiniLessonListener.tsx
@@ -8,15 +8,17 @@ const socketClient = new CreatorSocket(DEV_MODE ? "http://localhost:3000" : "");
 export default function MiniLessonListener() {
   const config = useStore((state) => state.configObject);
   const getSyllabus = useStore((state) => state.getSyllabus);
-  const getCurrentExercise = useStore((state) => state.getCurrentExercise);
 
   useEffect(() => {
     if (!config?.config?.slug) return;
 
     const handleUpdate = async (data: any) => {
-      const currentExercise = getCurrentExercise();
-      
-      if (data.status === "done" && data.lesson === currentExercise.slug) {
+      // Refresh the syllabus whenever any lesson reaches a terminal state, not
+      // just the one currently being viewed. Generation runs in the background
+      // for lessons other than the current one, and the sidebar loading state
+      // is driven entirely by the syllabus store, so it must be refreshed on
+      // every completion to reflect the real generation state.
+      if (data.status === "done" || data.status === "error") {
         getSyllabus();
       }
     };


### PR DESCRIPTION
Fixes learnpack/learnpack#1903

## Problema

En modo creador, el menú lateral muestra un spinner de carga en cada lección
que se está generando. Cuando una lección termina de generarse en segundo
plano, su fila sigue mostrando el spinner (o el icono de pausa) aunque el
contenido ya exista. Solo se actualiza al abrir esa lección o al cerrar y
volver a abrir el menú.

## Causa

El indicador de carga del menú se deriva por completo del store del temario
(`syllabus`): la fila muestra el `Loader` cuando `lesson.status ===
"GENERATING"` (`ExercisesList.tsx`). Ese store solo se refresca en vivo desde
`MiniLessonListener`, y su guardia era demasiado estricta:

```ts
const handleUpdate = async (data: any) => {
  const currentExercise = getCurrentExercise();
  if (data.status === "done" && data.lesson === currentExercise.slug) {
    getSyllabus();
  }
};
```

La generación es secuencial y ocurre en segundo plano para el resto de
lecciones (`continueWithNextLesson` en el CLI). Cada lección emite su evento
`done` por el canal `course-creation`, pero la condición `data.lesson ===
currentExercise.slug` descarta cualquier lección que no sea la que se está
viendo, así que `getSyllabus()` nunca se llama y su fila queda congelada en el
spinner. Los dos "arreglos" conocidos (abrir la lección, o reabrir el menú)
solo disparan manualmente ese refresco: el menú llama a `getSyllabus()` al
abrirse (`Sidebar.tsx`).

Además, esa guardia nunca coincidía para los eventos `error`, que emiten el
`uid` de la lección en lugar del slug, por lo que una lección con error también
se quedaba con el spinner.

## Solución

`MiniLessonListener` ahora refresca el temario ante cualquier estado terminal
(`done` o `error`) sin importar qué lección lo emita, que es la única fuente de
verdad que lee el menú:

```ts
const handleUpdate = async (data: any) => {
  if (data.status === "done" || data.status === "error") {
    getSyllabus();
  }
};
```

Se elimina la dependencia de `getCurrentExercise`.

Verificado con `tsc` (0 errores, sin cambios), `eslint` (mismo único error
preexistente de `no-explicit-any`, 0 nuevos), pruebas de comportamiento del
handler con los estados reales del canal (`generating` no refresca; `done` y
`error` sí, para cualquier lección) y manualmente en el IDE generando varias
lecciones en segundo plano con el menú abierto.

## Alcance

- Un único cambio de comportamiento: `getSyllabus()` se llama ante cada evento
  terminal de generación, no solo el de la lección visible. Es el mismo
  refresco que ya hace el menú al abrirse, ahora en el momento correcto.
- Solo se toca `MiniLessonListener`; el canal de socket, el backend y el resto
  de componentes quedan intactos.
- El canal `course-creation` solo emite `generating` / `done` / `error`, así
  que `done`/`error` cubre todos sus estados terminales.

## Nota (fuera del alcance de este PR)

Durante la investigación encontré una fragilidad adyacente, relacionada con
learnpack/learnpack#1757. `MiniLessonListener` y `RealtimeLesson` crean cada
uno un `CreatorSocket` con la misma URL, ruta y namespace, y socket.io
multiplexa esas conexiones en un único socket subyacente. Como consecuencia,
al desmontarse `RealtimeLesson` (por ejemplo al salir de una lección que se
estaba generando) su `disconnect()` puede cerrar el socket del que depende
`MiniLessonListener`, y las actualizaciones en vivo dejan de llegar hasta un
refresco completo. Es una condición preexistente que este PR no introduce ni
modifica, y encaja como una faceta concreta de la sincronización poco fiable ya
descrita en #1757. Lo dejo anotado para tratarlo por separado.
