### PR TITLE
fix: clean console.logs in production

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -22,7 +22,6 @@ export const Icon = ({
   const LucideIcon = Icons[name] as React.ComponentType<LucideProps>;
 
   if (!LucideIcon) {
-    console.warn(`Icon "${String(name)}" not found in lucide-react`);
     return null;
   }
 

--- a/src/components/Rigobot/AI.tsx
+++ b/src/components/Rigobot/AI.tsx
@@ -1,3 +1,4 @@
+import { describeError } from "../../utils/logging";
 import toast from "react-hot-toast";
 import {
   FASTAPI_HOST,
@@ -165,7 +166,7 @@ export const RigoTemplate = {
             return completionJob;
           }
         } catch (error) {
-          console.warn("Error fetching completion job", error);
+          console.warn("Error fetching completion job", describeError(error));
         }
         if (attempt < maxAttempts - 1) {
           await sleep(intervalMs);

--- a/src/components/Rigobot/NewAgent.tsx
+++ b/src/components/Rigobot/NewAgent.tsx
@@ -1,3 +1,4 @@
+import { describeError } from "../../utils/logging";
 import { useState, useEffect, useRef, memo } from "react";
 import { useTranslation } from "react-i18next";
 import SimpleButton from "../mockups/SimpleButton";
@@ -199,7 +200,7 @@ function setupPusherSubscription(
     });
 
     pusherClient.connection.bind("error", (err: any) => {
-      console.error("Pusher connection error:", err);
+      console.error("Pusher connection error:", describeError(err));
       callbacks.onError?.(err);
     });
 
@@ -207,7 +208,7 @@ function setupPusherSubscription(
       console.log("Pusher disconnected");
     });
   }).catch((error) => {
-    console.error("Failed to load Pusher:", error);
+    console.error("Failed to load Pusher:", describeError(error));
     callbacks.onError?.(error);
   });
 
@@ -497,7 +498,7 @@ export const AgentTab = () => {
         }
       }
     } catch (error) {
-      console.error("Error handling tool call:", error);
+      console.error("Error handling tool call:", describeError(error));
     }
   };
 
@@ -560,7 +561,7 @@ export const AgentTab = () => {
         console.error("Agent error:", data.error_message);
       }
     } catch (error) {
-      console.error("Error handling completion:", error);
+      console.error("Error handling completion:", describeError(error));
       toast.error("Error obteniendo resultados del agente");
     }
   };
@@ -698,7 +699,7 @@ ${context}
           await handleAgentCompletion(completionData);
         },
         onError: (error) => {
-          console.error("Pusher error:", error);
+          console.error("Pusher error:", describeError(error));
           toast.error("Error en la conexión en tiempo real");
         },
       });
@@ -708,7 +709,7 @@ ${context}
       // Poll for updates as fallback (optional, if Pusher fails)
       // You can implement polling here if needed
     } catch (error: any) {
-      console.error("Error starting agent run:", error);
+      console.error("Error starting agent run:", describeError(error));
       setIsGenerating(false);
       toast.error(error.message || "Error iniciando la conversación con el agente");
       

--- a/src/components/Rigobot/utils.ts
+++ b/src/components/Rigobot/utils.ts
@@ -26,7 +26,6 @@ export const slugToTitle = (slug: string, uppercase = true) => {
   if (!slug) return "";
 
   if (typeof slug !== "string") {
-    console.error("slugToTitle: slug is not a string");
     return "";
   }
   let title = slug.replace(/-/g, " ").replace(/_/g, " ");

--- a/src/components/composites/LessonRenderer/TestLatex.tsx
+++ b/src/components/composites/LessonRenderer/TestLatex.tsx
@@ -44,7 +44,6 @@ export const TestLatex = () => {
   const language = useStore((state) => state.language);
 
   const testLatex = async () => {
-    console.log("test", token, configObject?.config?.slug, language);
     const bod = {
       prompt: "Hello, world!",
     };

--- a/src/components/composites/PreviewImageGenerator/PreviewImageGenerator.tsx
+++ b/src/components/composites/PreviewImageGenerator/PreviewImageGenerator.tsx
@@ -61,7 +61,6 @@ const PreviewGenerator: React.FC = () => {
 
           canvas.toBlob(async (blob) => {
             if (!blob) {
-              console.error("No blob found");
               return;
             }
 

--- a/src/components/composites/QuizRenderer/QuizRenderer.tsx
+++ b/src/components/composites/QuizRenderer/QuizRenderer.tsx
@@ -355,8 +355,6 @@ const QuizQuestion = ({
         text: answer,
         isCorrect: isCorrect,
       });
-    } else {
-      console.error("No group ref found");
     }
   };
 

--- a/src/components/sections/modals/SyllabusFeedback.tsx
+++ b/src/components/sections/modals/SyllabusFeedback.tsx
@@ -1,3 +1,4 @@
+import { describeError } from "../../../utils/logging";
 import { useTranslation } from "react-i18next";
 import useStore from "../../../utils/store";
 import { Modal } from "../../mockups/Modal";
@@ -40,7 +41,7 @@ export const SyllabusFeedbackModal = () => {
         // setOpenedModals({ syllabusFeedback: false });
       })
       .catch((error) => {
-        console.error("Error continuing course:", error);
+        console.error("Error continuing course:", describeError(error));
       });
   };
 

--- a/src/components/sections/modals/VideoModal.tsx
+++ b/src/components/sections/modals/VideoModal.tsx
@@ -25,7 +25,6 @@ const VideoModal: React.FC<IVideoModalProps> = ({ link, hideModal }) => {
     }
 
     if (!videoId) {
-      console.error("Invalid YouTube link: missing video ID");
       return;
     }
 

--- a/src/hooks/useCompletionJobStatus.ts
+++ b/src/hooks/useCompletionJobStatus.ts
@@ -1,3 +1,4 @@
+import { describeError } from "../utils/logging";
 import { useState, useEffect, useRef } from "react";
 import axios from "axios";
 import { RIGOBOT_HOST } from "../utils/lib";
@@ -80,7 +81,7 @@ export const useCompletionJobStatus = ({
         });
       }
     } catch (error) {
-      console.error("Error polling completion status:", error);
+      console.error("Error polling completion status:", describeError(error));
       setStatus({
         status: "ERROR",
         error: error instanceof Error ? error.message : "Unknown error",

--- a/src/managers/EventProxy.ts
+++ b/src/managers/EventProxy.ts
@@ -1,3 +1,4 @@
+import { describeError } from "../utils/logging";
 import axios from "axios";
 import toast from "react-hot-toast";
 import { compileHTML, compileReactHTML } from "../utils/compileHTML";
@@ -82,7 +83,7 @@ function searchInputsForFile(filename: string, fileContent: string) {
     const fixedMatches = allMatches.map((match) => match.replace(/['"]/g, ""));
     return fixedMatches.length > 0 ? fixedMatches : null;
   } catch (error) {
-    console.error("Something went wrong searching inputs:", error);
+    console.error("Something went wrong searching inputs:", describeError(error));
     return null;
   }
 }
@@ -634,7 +635,7 @@ const rigoFetch = async (
     }
     return json;
   } catch (error) {
-    console.error("Error in API request:", error);
+    console.error("Error in API request:", describeError(error));
     throw error;
   }
 };

--- a/src/managers/fetchManager.ts
+++ b/src/managers/fetchManager.ts
@@ -1,3 +1,4 @@
+import { describeError } from "../utils/logging";
 import {
   BREATHECODE_HOST,
   getExercise,
@@ -871,13 +872,13 @@ export const FetchManager = {
               const { getSyncNotifications } = useStore.getState();
               getSyncNotifications().catch((err) => {
                 // Silently fail - non-critical operation
-                console.error("Error refreshing sync notifications:", err);
+                console.error("Error refreshing sync notifications:", describeError(err));
               });
             }
           } catch (notifError) {
             // Non-critical error - README was saved successfully
             // Don't show error to user - notification creation is optional
-            console.error("Error creating sync notification:", notifError);
+            console.error("Error creating sync notification:", describeError(notifError));
           }
         }
 
@@ -1223,7 +1224,7 @@ const createTabHashFromURL = () => {
     console.debug(hash, "HASH");
     return hash;
   } catch (error) {
-    console.error("Error generating tab hash:", error);
+    console.error("Error generating tab hash:", describeError(error));
     return uuidv4();
   }
 };

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -469,7 +469,7 @@ const sendStreamTelemetry = async function (
       return response;
     })
     .catch((error) => {
-      console.log("Error while sending stream Telemetry", error);
+      console.error("Error while sending stream Telemetry", describeError(error));
     });
 };
 
@@ -1019,8 +1019,10 @@ const TelemetryManager: ITelemetryManager = {
 
           submitLocalIfNewer = source === "local";
         } catch (error) {
-          console.log("ERROR: There was a problem starting the Telemetry");
-          console.error(describeError(error));
+          console.error(
+            "There was a problem starting the Telemetry",
+            describeError(error)
+          );
           throw new Error(
             "There was a problem starting, reload LearnPack\nRun\n$ learnpack start"
           );
@@ -1110,8 +1112,10 @@ const TelemetryManager: ITelemetryManager = {
         await this.submit();
       })
       .catch((error) => {
-        console.log("ERROR: There was a problem starting the Telemetry");
-        console.error(describeError(error));
+        console.error(
+          "There was a problem starting the Telemetry",
+          describeError(error)
+        );
 
         throw new Error(
           "There was a problem starting, reload LearnPack\nRun\n$ learnpack start"

--- a/src/managers/telemetry.ts
+++ b/src/managers/telemetry.ts
@@ -1,3 +1,4 @@
+import { describeError } from "../utils/logging";
 import {
   calculateIndicators,
   calculateTestMetrics,
@@ -56,13 +57,7 @@ const sendBatchTelemetryBreathecode = async function (
 
     return response.data;
   } catch (error) {
-    console.error("Error while sending batch telemetry", error);
-
-    if (axios.isAxiosError(error) && error.response) {
-      console.error("Response data:", error.response.data);
-      console.error("Response status:", error.response.status);
-      console.error("Response headers:", error.response.headers);
-    }
+    console.error("Error while sending batch telemetry", describeError(error));
     throw error;
   }
 };
@@ -81,7 +76,7 @@ const sendBatchTelemetryRigobot = async function (body: object, token: string) {
 
     return response.data;
   } catch (error) {
-    console.error("Error while sending batch telemetry", error);
+    console.error("Error while sending batch telemetry", describeError(error));
     throw error;
   }
 };
@@ -157,7 +152,7 @@ export async function fetchTelemetryFromServer(params: {
     if ((error as Error).name === "AbortError") {
       console.warn("fetchTelemetryFromServer: timeout or aborted");
     } else {
-      console.warn("fetchTelemetryFromServer: failed", error);
+      console.warn("fetchTelemetryFromServer: failed", describeError(error));
     }
     return null;
   } finally {
@@ -222,7 +217,7 @@ export async function fetchTelemetryWithStatus(params: {
       console.warn("fetchTelemetryWithStatus: timeout");
       return { status: "timeout" };
     }
-    console.warn("fetchTelemetryWithStatus: network error", error);
+    console.warn("fetchTelemetryWithStatus: network error", describeError(error));
     return { status: "timeout" };
   } finally {
     clearTimeout(timeoutId);
@@ -485,7 +480,7 @@ const retrieveFromCLI =
       // console.debug("Retrieved telemetry from CLI", response.data);
       return response.data;
     } catch (error) {
-      console.error("Error while retrieving telemetry from CLI", error);
+      console.error("Error while retrieving telemetry from CLI", describeError(error));
       return null;
     }
   };
@@ -499,7 +494,7 @@ const saveInCLI = async function (telemetry: ITelemetryJSONSchema) {
     console.debug("Saved telemetry in CLI", response.data);
     return response.data;
   } catch (error) {
-    console.error("Error while saving telemetry in CLI", error);
+    console.error("Error while saving telemetry in CLI", describeError(error));
     return null;
   }
 };
@@ -1025,7 +1020,7 @@ const TelemetryManager: ITelemetryManager = {
           submitLocalIfNewer = source === "local";
         } catch (error) {
           console.log("ERROR: There was a problem starting the Telemetry");
-          console.error(error);
+          console.error(describeError(error));
           throw new Error(
             "There was a problem starting, reload LearnPack\nRun\n$ learnpack start"
           );
@@ -1116,7 +1111,7 @@ const TelemetryManager: ITelemetryManager = {
       })
       .catch((error) => {
         console.log("ERROR: There was a problem starting the Telemetry");
-        console.error(error);
+        console.error(describeError(error));
 
         throw new Error(
           "There was a problem starting, reload LearnPack\nRun\n$ learnpack start"
@@ -1629,7 +1624,7 @@ const TelemetryManager: ITelemetryManager = {
       }
       this.save();
     } catch (error) {
-      console.error("Error submitting telemetry", error);
+      console.error("Error submitting telemetry", describeError(error));
     }
   },
   save: function () {

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -182,8 +182,6 @@ export const isPackageAuthor = async (
 ): Promise<{ isAuthor: boolean; status: number }> => {
   const url = `${RIGOBOT_HOST}/v1/learnpack/package/${packageSlug}/`;
 
-  console.log("Checking if package is author", url, token);
-
   const headers = {
     Authorization: `Token ${token}`,
   };

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -1,3 +1,4 @@
+import { describeError } from "./logging";
 import axios from "axios";
 import { RIGOBOT_HOST, BREATHECODE_HOST } from "./lib";
 import { TConsumableSlug } from "./storeTypes";
@@ -19,7 +20,7 @@ export const getSession = async (token: string, slug: string) => {
 
     return response.data;
   } catch (error) {
-    console.error("Error fetching session:", error);
+    console.error("Error fetching session:", describeError(error));
     throw error;
   }
 };
@@ -48,7 +49,7 @@ export const updateSession = async (
     });
     return response.data;
   } catch (error) {
-    console.error("Error updating session:", error);
+    console.error("Error updating session:", describeError(error));
     throw error;
   }
 };
@@ -77,7 +78,7 @@ export const createSession = async (
 
     return response.data;
   } catch (error) {
-    console.error("Error creating session:", error);
+    console.error("Error creating session:", describeError(error));
     throw error; // Rethrow the error for further handling
   }
 };
@@ -93,7 +94,7 @@ export async function getConsumables(token: string): Promise<any> {
     const response = await axios.get(url, { headers });
     return response.data;
   } catch (error) {
-    console.error("Error fetching consumables:", error);
+    console.error("Error fetching consumables:", describeError(error));
     throw error;
   }
 }
@@ -121,7 +122,7 @@ export async function useConsumableCall(
       return false;
     }
   } catch (error) {
-    console.error(`Error consuming ${consumableSlug}:`, error);
+    console.error(`Error consuming ${consumableSlug}:`, describeError(error));
     return false;
   }
 }
@@ -171,7 +172,7 @@ export async function fetchLearnpackPackageInfo(
     if (axios.isAxiosError(error) && error.response?.status === 404) {
       return empty;
     }
-    console.warn("fetchLearnpackPackageInfo failed:", error);
+    console.warn("fetchLearnpackPackageInfo failed:", describeError(error));
     return empty;
   }
 }
@@ -191,7 +192,7 @@ export const isPackageAuthor = async (
     return { isAuthor: response.status === 200, status: response.status };
   } catch (error: any) {
     const status = error?.response?.status || 500;
-    console.error("Error fetching package:", error);
+    console.error("Error fetching package:", describeError(error));
     return { isAuthor: false, status };
   }
 };

--- a/src/utils/creator.ts
+++ b/src/utils/creator.ts
@@ -1,3 +1,4 @@
+import { describeError } from "./logging";
 import axios from "axios";
 import { getSlugFromPath, LEARNPACK_LOCAL_URL } from "./lib";
 
@@ -23,7 +24,7 @@ export const createStep = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error creating step:", error);
+    console.error("Error creating step:", describeError(error));
     throw error;
   }
 };
@@ -38,7 +39,7 @@ export const deleteExercise = async (slug: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error deleting exercise:", error);
+    console.error("Error deleting exercise:", describeError(error));
     throw error;
   }
 };
@@ -57,7 +58,7 @@ export const renameExercise = async (slug: string, newSlug: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error renaming exercise:", error);
+    console.error("Error renaming exercise:", describeError(error));
     throw error;
   }
 };
@@ -73,7 +74,7 @@ export const getUserAcademies = async (breathecodeToken: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error fetching academies:", error);
+    console.error("Error fetching academies:", describeError(error));
     throw error;
   }
 };
@@ -101,7 +102,7 @@ export const getPackageAcademy = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error fetching package academy:", error);
+    console.error("Error fetching package academy:", describeError(error));
     throw error;
   }
 };
@@ -128,7 +129,7 @@ export const publishTutorial = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error publishing tutorial:", error);
+    console.error("Error publishing tutorial:", describeError(error));
     throw error;
   }
 };
@@ -149,7 +150,7 @@ export const deleteTutorial = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error deleting tutorial:", error);
+    console.error("Error deleting tutorial:", describeError(error));
     throw error;
   }
 };
@@ -174,7 +175,7 @@ export const updateCourseTitle = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error updating course title:", error);
+    console.error("Error updating course title:", describeError(error));
     throw error;
   }
 };
@@ -187,7 +188,7 @@ export const synchronizeSyllabus = async () => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error synchronizing syllabus:", error);
+    console.error("Error synchronizing syllabus:", describeError(error));
     throw error;
   }
 };
@@ -211,7 +212,7 @@ export const synchronizeLessonFiles = async (
       movedCount?: number;
     };
   } catch (error) {
-    console.error("Error synchronizing lesson files:", error);
+    console.error("Error synchronizing lesson files:", describeError(error));
     throw error;
   }
 };
@@ -374,7 +375,7 @@ export const createFile = async (exerciseSlug: string, filename: string, content
     );
     return response.data;
   } catch (error) {
-    console.error("Error creating file:", error);
+    console.error("Error creating file:", describeError(error));
     throw error;
   }
 };
@@ -389,7 +390,7 @@ export const deleteFile = async (exerciseSlug: string, filename: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error deleting file:", error);
+    console.error("Error deleting file:", describeError(error));
     throw error;
   }
 };
@@ -412,7 +413,7 @@ export const renameFile = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error renaming file:", error);
+    console.error("Error renaming file:", describeError(error));
     throw error;
   }
 };
@@ -433,7 +434,7 @@ export const changeSlug = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error changing slug:", error);
+    console.error("Error changing slug:", describeError(error));
     throw error;
   }
 };
@@ -445,7 +446,7 @@ export const getGithubStatus = async (courseSlug: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error fetching GitHub status:", error);
+    console.error("Error fetching GitHub status:", describeError(error));
     throw error;
   }
 };
@@ -468,7 +469,7 @@ export const createGithubRepo = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error creating GitHub repo:", error);
+    console.error("Error creating GitHub repo:", describeError(error));
     if (axios.isAxiosError(error)) {
       const data = error.response?.data as {
         message?: string;
@@ -517,7 +518,7 @@ export const checkGithubChanges = async (courseSlug: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error checking GitHub changes:", error);
+    console.error("Error checking GitHub changes:", describeError(error));
     throw error;
   }
 };
@@ -536,7 +537,7 @@ export const pullFromGithub = async (
     );
     return response.data;
   } catch (error) {
-    console.error("Error pulling from GitHub:", error);
+    console.error("Error pulling from GitHub:", describeError(error));
     throw error;
   }
 };
@@ -549,7 +550,7 @@ export const pushToGithub = async (courseSlug: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error pushing to GitHub:", error);
+    console.error("Error pushing to GitHub:", describeError(error));
     throw error;
   }
 };

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -1,3 +1,4 @@
+import { describeError } from "./logging";
 import { TEnvironment } from "../managers/EventProxy";
 import { TPossibleParams, TSidebar } from "./storeTypes";
 // @ts-ignore
@@ -174,7 +175,7 @@ export const getEnvironment = async () => {
         document.dispatchEvent(myEvent);
         return "scorm";
       } catch (e) {
-        console.error("Error fetching scorm config, impossible to detect environment", e);
+        console.error("Error fetching scorm config, impossible to detect environment", describeError(e));
         return "localStorage";
       }
     }
@@ -417,7 +418,7 @@ export function hashText(text: string, callback: (hash: string) => void) {
       callback(hashHex); // Call the callback function with the hashed text
     })
     .catch((err) => {
-      console.error("Hashing failed:", err); // Handle any errors
+      console.error("Hashing failed:", describeError(err)); // Handle any errors
     });
 }
 
@@ -531,7 +532,7 @@ export const playEffect = (mood: "success" | "error") => {
     audio.volume = 0.4;
     audio.play();
   } catch (error) {
-    console.error("Error playing sound", error);
+    console.error("Error playing sound", describeError(error));
   }
 };
 
@@ -700,7 +701,7 @@ export const checkPreviewImage = async (slug: string) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error checking preview image", error);
+    console.error("Error checking preview image", describeError(error));
     return null;
   }
 };
@@ -743,7 +744,7 @@ export const isSlugAvailable = async (slug: string): Promise<boolean> => {
     const response = await axios.get<SlugAvailabilityResponse>(url)
     return response.data.available
   } catch (error) {
-    console.error("Error checking slug availability:", error)
+    console.error("Error checking slug availability:", describeError(error))
     throw error
   }
 }
@@ -777,7 +778,7 @@ export const generateImage = async (
 
     return response.data;
   } catch (error) {
-    console.error("Error generating image:", error);
+    console.error("Error generating image:", describeError(error));
     return null;
   }
 };
@@ -874,7 +875,7 @@ const parseYamlComponents = (raw: string): TYamlComponent[] => {
     const parsed = yaml.load(raw) as { components?: TYamlComponent[] };
     return parsed?.components ?? [];
   } catch (error) {
-    console.error("Error parsing components YAML:", error);
+    console.error("Error parsing components YAML:", describeError(error));
     return [];
   }
 };

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
 
 /**
- * Utilidades para registrar errores en consola sin exponer credenciales.
+ * Helpers for logging errors to the console without exposing credentials.
  *
- * El objeto de error de axios arrastra `config.headers` (con `Authorization`
- * o `x-rigo-token`), `request` y `response.headers`. Volcarlo entero con
- * `console.error("...", error)` publica el token del usuario en las devtools.
- * `describeError` se queda solo con lo que sirve para diagnosticar.
+ * An axios error object carries `config.headers` (holding `Authorization` or
+ * `x-rigo-token`), `request` and `response.headers`. Dumping it whole with
+ * `console.error("...", error)` publishes the user's token to the devtools.
+ * `describeError` keeps only what is useful for diagnosis.
  */
 
 export type TSafeErrorInfo = {
@@ -22,7 +22,7 @@ export type TSafeErrorInfo = {
 
 const MAX_DATA_CHARS = 500;
 
-/** Parametros de query cuyo valor nunca debe aparecer en un log. */
+/** Query parameters whose value must never show up in a log. */
 const SENSITIVE_QUERY_PARAMS = [
   "token",
   "access_token",
@@ -35,10 +35,10 @@ const SENSITIVE_QUERY_PARAMS = [
 ];
 
 /**
- * Devuelve la URL sin los valores de los parametros sensibles. Algunas
- * peticiones llevan el token en la query (por ejemplo
- * `/v1/auth/me/token?breathecode_token=...`), asi que no basta con omitir
- * las cabeceras.
+ * Returns the URL with the values of sensitive parameters redacted. Some
+ * requests carry the token in the query string (for example
+ * `/v1/auth/me/token?breathecode_token=...`), so omitting the headers is not
+ * enough.
  */
 export const redactUrl = (url?: string): string | undefined => {
   if (!url) return undefined;
@@ -59,7 +59,7 @@ export const redactUrl = (url?: string): string | undefined => {
   return `${base}?${redactedQuery}`;
 };
 
-/** Serializa el cuerpo de la respuesta y lo recorta para no inundar la consola. */
+/** Serializes the response body and truncates it so it does not flood the console. */
 const summarizeData = (data: unknown): unknown => {
   if (data === null || data === undefined) return undefined;
 
@@ -78,8 +78,8 @@ const summarizeData = (data: unknown): unknown => {
 };
 
 /**
- * Extrae de un error los datos utiles para soporte (mensaje, estado, metodo y
- * URL) omitiendo siempre cabeceras y configuracion de la peticion.
+ * Extracts the data that is useful for support (message, status, method and
+ * URL) from an error, always omitting request headers and configuration.
  */
 export const describeError = (error: unknown): TSafeErrorInfo => {
   if (axios.isAxiosError(error)) {
@@ -94,8 +94,8 @@ export const describeError = (error: unknown): TSafeErrorInfo => {
     };
   }
 
-  // En los errores que no son de red (parseo, Pusher, hashing...) la traza es
-  // el dato de diagnostico principal y no contiene credenciales.
+  // For non-network errors (parsing, Pusher, hashing...) the stack is the main
+  // diagnostic signal and holds no credentials.
   if (error instanceof Error) {
     return { message: error.message, name: error.name, stack: error.stack };
   }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,0 +1,104 @@
+import axios from "axios";
+
+/**
+ * Utilidades para registrar errores en consola sin exponer credenciales.
+ *
+ * El objeto de error de axios arrastra `config.headers` (con `Authorization`
+ * o `x-rigo-token`), `request` y `response.headers`. Volcarlo entero con
+ * `console.error("...", error)` publica el token del usuario en las devtools.
+ * `describeError` se queda solo con lo que sirve para diagnosticar.
+ */
+
+export type TSafeErrorInfo = {
+  message: string;
+  name?: string;
+  status?: number;
+  statusText?: string;
+  method?: string;
+  url?: string;
+  data?: unknown;
+  stack?: string;
+};
+
+const MAX_DATA_CHARS = 500;
+
+/** Parametros de query cuyo valor nunca debe aparecer en un log. */
+const SENSITIVE_QUERY_PARAMS = [
+  "token",
+  "access_token",
+  "breathecode_token",
+  "rigo_token",
+  "api_key",
+  "key",
+  "password",
+  "secret",
+];
+
+/**
+ * Devuelve la URL sin los valores de los parametros sensibles. Algunas
+ * peticiones llevan el token en la query (por ejemplo
+ * `/v1/auth/me/token?breathecode_token=...`), asi que no basta con omitir
+ * las cabeceras.
+ */
+export const redactUrl = (url?: string): string | undefined => {
+  if (!url) return undefined;
+
+  const [base, query] = url.split("?");
+  if (!query) return base;
+
+  const redactedQuery = query
+    .split("&")
+    .map((pair) => {
+      const [name] = pair.split("=");
+      return SENSITIVE_QUERY_PARAMS.includes(name.toLowerCase())
+        ? `${name}=[REDACTADO]`
+        : pair;
+    })
+    .join("&");
+
+  return `${base}?${redactedQuery}`;
+};
+
+/** Serializa el cuerpo de la respuesta y lo recorta para no inundar la consola. */
+const summarizeData = (data: unknown): unknown => {
+  if (data === null || data === undefined) return undefined;
+
+  let asText: string;
+  try {
+    asText = typeof data === "string" ? data : JSON.stringify(data);
+  } catch {
+    return "[no serializable]";
+  }
+
+  if (typeof asText !== "string") return undefined;
+
+  return asText.length > MAX_DATA_CHARS
+    ? `${asText.slice(0, MAX_DATA_CHARS)}... [truncado]`
+    : asText;
+};
+
+/**
+ * Extrae de un error los datos utiles para soporte (mensaje, estado, metodo y
+ * URL) omitiendo siempre cabeceras y configuracion de la peticion.
+ */
+export const describeError = (error: unknown): TSafeErrorInfo => {
+  if (axios.isAxiosError(error)) {
+    return {
+      message: error.message,
+      name: error.name,
+      status: error.response?.status,
+      statusText: error.response?.statusText,
+      method: error.config?.method?.toUpperCase(),
+      url: redactUrl(error.config?.url),
+      data: summarizeData(error.response?.data),
+    };
+  }
+
+  // En los errores que no son de red (parseo, Pusher, hashing...) la traza es
+  // el dato de diagnostico principal y no contiene credenciales.
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name, stack: error.stack };
+  }
+
+  return { message: String(error) };
+};

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { describeError } from "./logging";
 
 // import io from "socket.io-client";
 
@@ -1062,7 +1063,7 @@ The user's set up the application in "${language}" language, give your feedback 
 
       return true;
     } catch (err) {
-      console.log(err, "ERROR FETCHING EXERCISES!");
+      console.error("Error fetching exercises", describeError(err));
       disconnected();
       return false;
     }
@@ -3583,7 +3584,7 @@ The user's set up the application in "${language}" language, give your feedback 
     const { token, environment, mode } = get();
 
     if (!token) {
-      console.log("ERROR: No token found, initializing RigoAI failed");
+      console.error("No token found, initializing RigoAI failed");
       return;
     }
 

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -2350,8 +2350,7 @@ The user's set up the application in "${language}" language, give your feedback 
         return;
       }
     } catch (e) {
-      console.error(e);
-      console.log("Error trying to get session");
+      console.error("Error trying to get session", describeError(e));
     }
   },
   updateDBSession: async () => {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -831,7 +831,6 @@ const useStore = create<IStore>((set, get) => ({
       if (params.token) {
         set({ bc_token: params.token });
         json = await FetchManager.loginWithToken(params.token);
-        console.log("json login with token", json);
         set({ token: json.rigoToken });
         set({ user: json.user });
         setTimeout(() => {
@@ -936,8 +935,6 @@ The user's set up the application in "${language}" language, give your feedback 
 
   fetchExercises: async () => {
     const { user_id, setOpenedModals, environment, token } = get();
-
-    console.log("Fetching exercises", environment, token);
 
     if (environment === "creatorWeb") {
       const slug = getSlugFromPath();
@@ -2204,7 +2201,6 @@ The user's set up the application in "${language}" language, give your feedback 
       mode,
     } = get();
 
-    console.log("tokens runnin tests", token, bc_token);
     if (!Boolean(token) || !Boolean(bc_token)) {
       setOpenedModals({ mustLogin: true });
       return;
@@ -2286,9 +2282,6 @@ The user's set up the application in "${language}" language, give your feedback 
     }
 
     const fallbackSlug = getSlugFromPath();
-
-    console.log("Getting session", token, configObject.config.slug);
-
 
     try {
       const session = await getSession(token, configObject.config.slug || fallbackSlug || "");

--- a/src/utils/syncNotifications.ts
+++ b/src/utils/syncNotifications.ts
@@ -1,3 +1,4 @@
+import { describeError } from "./logging";
 import { FetchManager } from "../managers/fetchManager";
 import { getSlugFromPath } from "./lib";
 
@@ -52,7 +53,7 @@ export const createSyncNotification = async (
     return data;
     
   } catch (error) {
-    console.error("Error in createSyncNotification:", error);
+    console.error("Error in createSyncNotification:", describeError(error));
     throw error;
   }
 };
@@ -84,7 +85,7 @@ export const fetchSyncNotifications = async (): Promise<any> => {
     return await response.json();
     
   } catch (error) {
-    console.error("Error fetching sync notifications:", error);
+    console.error("Error fetching sync notifications:", describeError(error));
     throw error;
   }
 };
@@ -117,7 +118,7 @@ export const dismissSyncNotification = async (
     }
     
   } catch (error) {
-    console.error("Error dismissing notification:", error);
+    console.error("Error dismissing notification:", describeError(error));
     throw error;
   }
 };
@@ -153,7 +154,7 @@ export const acceptSyncNotification = async (
     }
     
   } catch (error) {
-    console.error("Error accepting sync notification:", error);
+    console.error("Error accepting sync notification:", describeError(error));
     throw error;
   }
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,10 +20,11 @@ export default defineConfig({
     },
     cssCodeSplit: false,
   },
-  // `minify: true` (esbuild) no elimina las llamadas a consola, asi que todos
-  // los console.log del proyecto acababan en el bundle. Se descartan solo los
-  // informativos: console.error y console.warn se conservan porque son el
-  // unico canal de diagnostico del IDE (no hay Sentry ni ErrorBoundary).
+  // `minify: true` (esbuild) minifies but does not strip console calls, so
+  // every console.log in the project used to end up in the bundle. Only the
+  // informational ones are dropped: console.error and console.warn are kept
+  // because they are the IDE's only diagnostic channel (there is no Sentry
+  // and no ErrorBoundary).
   esbuild: {
     pure: ["console.log", "console.debug", "console.info"],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
     },
     cssCodeSplit: false,
   },
+  // `minify: true` (esbuild) no elimina las llamadas a consola, asi que todos
+  // los console.log del proyecto acababan en el bundle. Se descartan solo los
+  // informativos: console.error y console.warn se conservan porque son el
+  // unico canal de diagnostico del IDE (no hay Sentry ni ErrorBoundary).
+  esbuild: {
+    pure: ["console.log", "console.debug", "console.info"],
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
fix learnpack/learnpack#2111

## Fuga de tokens en los logs de producción

El bundle exponía credenciales en la consola del navegador por dos vías: seis `console.log` que volcaban el `rigoToken` y el `bc_token` (uno de ellos, la respuesta completa del login), y los `console.error` que registraban el error de axios entero, arrastrando `config.headers` con la cabecera de autenticación. Agravado por `minify: true` (esbuild), que no elimina las llamadas a consola.

Se eliminan los seis `console.log` con credenciales y se añade el helper `describeError` (`src/utils/logging.ts`), que conserva mensaje, estado, método y URL, descarta siempre cabeceras y configuración, y redacta los parámetros de query sensibles (alguna petición lleva el token en la URL). Aplicado en los 11 archivos que manejan tokens.

## Limpieza de console.logs en producción

`vite.config.ts` añade `esbuild.pure` para descartar `console.log/debug/info` y **conservar** `console.error` y `console.warn`.

Verificado sobre el bundle compilado: las cinco cadenas con token pasan de 1 a 0 apariciones y los mensajes de diagnóstico siguen presentes.